### PR TITLE
Add a mini ORM to allow querying of data in a CakePHP manner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
 
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:1.0.0; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
 script:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ use Cake\Network\Http\Client;
 use Muffin\Webservice\QueryLogger;
 use Muffin\Webservice\ResultSet;
 use Muffin\Webservice\WebserviceInterface;
-use Muffin\Webservice\WebserviceQuery;
+use Muffin\Webservice\Query;
 
 class ArticlesWebservice implements WebserviceInterface
 {
@@ -63,10 +63,10 @@ class ArticlesWebservice implements WebserviceInterface
         return new QueryLogger();
     }
 
-    public function execute(WebserviceQuery $query)
+    public function execute(Query $query)
     {
         switch ($query->action()) {
-            case WebserviceQuery::ACTION_READ:
+            case Query::ACTION_READ:
                 $client = new Client();
                 $response = $client->get('http://example.com/articles.json');
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
     },
     "require-dev": {
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "dev-master",
         "cakephp/cakephp-codesniffer": "2.*",
         "phpunit/phpunit": "4.1.*"
     },

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+use Cake\Event\EventManager;
+
+EventManager::instance()->on(
+    'Dispatcher.beforeDispatch',
+    ['priority' => 51],
+    function ($event) {
+        $controller = false;
+        if (isset($event->data['controller'])) {
+            $controller = $event->data['controller'];
+        }
+        if ($controller) {
+            $callback = ['Muffin\Webservice\Model\EndpointRegistry', 'get'];
+            $controller->modelFactory('Endpoint', $callback);
+        }
+    }
+);

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,18 +1,3 @@
 <?php
 
-use Cake\Event\EventManager;
-
-EventManager::instance()->on(
-    'Dispatcher.beforeDispatch',
-    ['priority' => 51],
-    function ($event) {
-        $controller = false;
-        if (isset($event->data['controller'])) {
-            $controller = $event->data['controller'];
-        }
-        if ($controller) {
-            $callback = ['Muffin\Webservice\Model\EndpointRegistry', 'get'];
-            $controller->modelFactory('Endpoint', $callback);
-        }
-    }
-);
+\Cake\Routing\DispatcherFactory::add('Muffin/Webservice.ControllerEndpoint');

--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -75,7 +75,7 @@ abstract class AbstractDriver implements LoggerAwareInterface
      * Set or get a instance of a webservice
      *
      * @param string $name The name of the webservice
-     * @param WebserviceInterface|null $webservice The instance of the webservice you'd like to set
+     * @param \Muffin\Webservice\Webservice\WebserviceInterface|null $webservice The instance of the webservice you'd like to set
      *
      * @return $this
      */

--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -46,7 +46,7 @@ abstract class AbstractDriver implements LoggerAwareInterface
     /**
      * Set or return an instance of the client used for communication
      *
-     * @param object $client
+     * @param object $client The client to use
      *
      * @return $this
      */
@@ -61,6 +61,14 @@ abstract class AbstractDriver implements LoggerAwareInterface
         return $this;
     }
 
+    /**
+     * Set or get a instance of a webservice
+     *
+     * @param string $name The name of the webservice
+     * @param WebserviceInterface|null $webservice The instance of the webservice you'd like to set
+     *
+     * @return $this
+     */
     public function webservice($name, WebserviceInterface $webservice = null)
     {
         if ($webservice !== null) {
@@ -112,7 +120,7 @@ abstract class AbstractDriver implements LoggerAwareInterface
     /**
      * Enables or disables query logging for this driver
      *
-     * @param boolean|null $enable whether to turn logging on or disable it.
+     * @param bool|null $enable whether to turn logging on or disable it.
      *   Use null to read current value.
      *
      * @return bool
@@ -131,7 +139,9 @@ abstract class AbstractDriver implements LoggerAwareInterface
      *
      * @param string $method Method name.
      * @param array $args Arguments to pass-through.
+     *
      * @return mixed
+     *
      * @throws \RuntimeException If the client object has not been initialized.
      * @throws \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException If the method does not exist in the client.
      */
@@ -154,6 +164,11 @@ abstract class AbstractDriver implements LoggerAwareInterface
         return call_user_func_array([$this->_client, $method], $args);
     }
 
+    /**
+     * Returns a handy representation of this driver
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -21,8 +21,18 @@ abstract class AbstractDriver implements LoggerAwareInterface
 
     protected $_defaultConfig = [];
 
+    /**
+     * Whatever queries should be logged
+     *
+     * @var bool
+     */
     protected $_logQueries = false;
 
+    /**
+     * The list of webservices to be used
+     *
+     * @var array
+     */
     protected $_webservices = [];
 
     /**

--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -1,17 +1,29 @@
 <?php
 namespace Muffin\Webservice;
 
+use Cake\Core\App;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Utility\Inflector;
+use Muffin\Webservice\Exception\MissingWebserviceClassException;
 use Muffin\Webservice\Exception\UnimplementedWebserviceMethodException;
+use Muffin\Webservice\Webservice\WebserviceInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use RuntimeException;
 
-abstract class AbstractDriver
+abstract class AbstractDriver implements LoggerAwareInterface
 {
+
     use InstanceConfigTrait;
+    use LoggerAwareTrait;
 
     protected $_client;
 
     protected $_defaultConfig = [];
+
+    protected $_logQueries = false;
+
+    protected $_webservices = [];
 
     /**
      * Constructor.
@@ -31,6 +43,79 @@ abstract class AbstractDriver
      */
     abstract public function initialize();
 
+    public function client($client = null)
+    {
+        if ($client === null) {
+            return $this->_client;
+        }
+
+        $this->_client = $client;
+
+        return $this;
+    }
+
+    public function webservice($name, WebserviceInterface $webservice = null)
+    {
+        if ($webservice === null) {
+            if (!isset($this->_webservices[$name])) {
+                $namespaceParts = explode('\\', get_class($this));
+
+                $pluginName = implode('/', array_reverse(array_slice(array_reverse($namespaceParts), -2)));
+
+                $webserviceClass = $pluginName . '.' . Inflector::camelize($name);
+                $webservice = App::className($webserviceClass, 'Webservice', 'Webservice');
+                if (!$webservice) {
+                    $fallbackWebserviceClass = $pluginName . '.' . end($namespaceParts);
+                    $webservice = App::className($fallbackWebserviceClass, 'Webservice', 'Webservice');
+
+                    if (!$webservice) {
+                        throw new MissingWebserviceClassException([
+                            'class' => $webserviceClass,
+                            'fallbackClass' => $fallbackWebserviceClass
+                        ]);
+                    }
+                }
+
+                $webservice = new $webservice([
+                    'endpoint' => $name,
+                    'driver' => $this,
+                ]);
+
+                $this->_webservices[$name] = $webservice;
+            }
+
+            return $this->_webservices[$name];
+        }
+
+        $this->_webservices[$name] = $webservice;
+
+        return $this;
+    }
+
+    /**
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function logger()
+    {
+        return $this->logger;
+    }
+
+    public function configName()
+    {
+        if (empty($this->_config['name'])) {
+            return '';
+        }
+        return $this->_config['name'];
+    }
+
+    public function logQueries($enable = null)
+    {
+        if ($enable === null) {
+            return $this->_logQueries;
+        }
+        $this->_logQueries = $enable;
+    }
+
     /**
      * Proxies the client's methods.
      *
@@ -42,14 +127,14 @@ abstract class AbstractDriver
      */
     public function __call($method, $args)
     {
-        if (!is_object($this->_client)) {
+        if (!is_object($this->client())) {
             throw new RuntimeException(sprintf(
                 'The `%s` client has not been initialized',
                 $this->config('name')
             ));
         }
 
-        if (!method_exists($this->_client, $method)) {
+        if (!method_exists($this->client(), $method)) {
             throw new UnimplementedWebserviceMethodException([
                 'name' => $this->config('name'),
                 'method' => $method
@@ -57,5 +142,14 @@ abstract class AbstractDriver
         }
 
         return call_user_func_array([$this->_client, $method], $args);
+    }
+
+    public function __debugInfo()
+    {
+        return [
+            'client' => $this->client(),
+            'logger' => $this->logger(),
+            'webservices' => array_keys($this->_webservices)
+        ];
     }
 }

--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -43,6 +43,13 @@ abstract class AbstractDriver implements LoggerAwareInterface
      */
     abstract public function initialize();
 
+    /**
+     * Set or return an instance of the client used for communication
+     *
+     * @param object $client
+     *
+     * @return $this
+     */
     public function client($client = null)
     {
         if ($client === null) {
@@ -93,6 +100,8 @@ abstract class AbstractDriver implements LoggerAwareInterface
     }
 
     /**
+     * Returns a logger instance
+     *
      * @return \Psr\Log\LoggerInterface
      */
     public function logger()
@@ -100,6 +109,11 @@ abstract class AbstractDriver implements LoggerAwareInterface
         return $this->logger;
     }
 
+    /**
+     * Returns the connection name used in the configuration
+     *
+     * @return string
+     */
     public function configName()
     {
         if (empty($this->_config['name'])) {
@@ -108,6 +122,14 @@ abstract class AbstractDriver implements LoggerAwareInterface
         return $this->_config['name'];
     }
 
+    /**
+     * Enables or disables query logging for this driver
+     *
+     * @param boolean|null $enable whether to turn logging on or disable it.
+     *   Use null to read current value.
+     *
+     * @return bool
+     */
     public function logQueries($enable = null)
     {
         if ($enable === null) {

--- a/src/Exception/MissingResourceClassException.php
+++ b/src/Exception/MissingResourceClassException.php
@@ -8,5 +8,4 @@ class MissingResourceClassException extends Exception
 {
 
     protected $_messageTemplate = 'Resource class %s could not be found.';
-
 }

--- a/src/Exception/MissingResourceClassException.php
+++ b/src/Exception/MissingResourceClassException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Muffin\Webservice\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class MissingResourceClassException extends Exception
+{
+
+    protected $_messageTemplate = 'Resource class %s could not be found.';
+
+}

--- a/src/Exception/MissingWebserviceClassException.php
+++ b/src/Exception/MissingWebserviceClassException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Muffin\Webservice\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class MissingWebserviceClassException extends Exception
+{
+
+    protected $_messageTemplate = 'Webservice class %s (and fallback %s) could not be found.';
+
+}

--- a/src/Exception/MissingWebserviceClassException.php
+++ b/src/Exception/MissingWebserviceClassException.php
@@ -8,5 +8,4 @@ class MissingWebserviceClassException extends Exception
 {
 
     protected $_messageTemplate = 'Webservice class %s (and fallback %s) could not be found.';
-
 }

--- a/src/Exception/UnimplementedDriverMethodException.php
+++ b/src/Exception/UnimplementedDriverMethodException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Muffin\Webservice\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class UnimplementedDriverMethodException extends Exception
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_messageTemplate = 'Driver (`%s`) does not implement `%s`';
+}

--- a/src/Exception/UnimplementedWebserviceMethodException.php
+++ b/src/Exception/UnimplementedWebserviceMethodException.php
@@ -9,5 +9,5 @@ class UnimplementedWebserviceMethodException extends Exception
     /**
      * {@inheritDoc}
      */
-    protected $_messageTemplate = 'Driver (`%s`) does not implement `%s`';
+    protected $_messageTemplate = 'Webservice %s does not implement %s';
 }

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -52,7 +52,7 @@ class Marshaller
 
         $primaryKey = $this->_endpoint->primaryKey();
         $resourceClass = $this->_endpoint->resourceClass();
-        /** @var \Muffin\Webservice\Model\Resource $entity */
+        /* @var \Muffin\Webservice\Model\Resource $entity */
         $entity = new $resourceClass();
         $entity->source($this->_endpoint->registryAlias());
 

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -1,0 +1,297 @@
+<?php
+namespace Muffin\Webservice;
+
+use ArrayObject;
+use Cake\Collection\Collection;
+use Cake\Datasource\EntityInterface;
+use Muffin\Webservice\Model\Endpoint;
+use RuntimeException;
+
+/**
+ * Contains logic to convert array data into resources.
+ *
+ * Useful when converting request data into resources.
+ */
+class Marshaller
+{
+
+    /**
+     * The endpoint instance this marshaller is for.
+     *
+     * @var \Muffin\Webservice\Model\Endpoint
+     */
+    protected $_endpoint;
+
+    /**
+     * Constructor.
+     *
+     * @param \Muffin\Webservice\Model\Endpoint $endpoint The endpoint this marshaller is for.
+     */
+    public function __construct(Endpoint $endpoint)
+    {
+        $this->_endpoint = $endpoint;
+    }
+
+    /**
+     * Hydrate one entity.
+     *
+     * ### Options:
+     *
+     * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     *   the accessible fields list in the entity will be used.
+     * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * @param array $data The data to hydrate.
+     * @param array $options List of options
+     * @return \Cake\ORM\Entity
+     * @see \Muffin\Webservice\Model\Endpoint::newEntity()
+     */
+    public function one(array $data, array $options = [])
+    {
+        list($data, $options) = $this->_prepareDataAndOptions($data, $options);
+
+        $primaryKey = $this->_endpoint->primaryKey();
+        $resourceClass = $this->_endpoint->resourceClass();
+        /** @var \Muffin\Webservice\Model\Resource $entity */
+        $entity = new $resourceClass();
+        $entity->source($this->_endpoint->registryAlias());
+
+        if (isset($options['accessibleFields'])) {
+            foreach ((array)$options['accessibleFields'] as $key => $value) {
+                $entity->accessible($key, $value);
+            }
+        }
+
+        $errors = $this->_validate($data, $options, true);
+        $properties = [];
+        foreach ($data as $key => $value) {
+            if (!empty($errors[$key])) {
+                continue;
+            }
+            if ($value === '' && in_array($key, $primaryKey, true)) {
+                // Skip marshalling '' for pk fields.
+                continue;
+            }
+            $properties[$key] = $value;
+        }
+
+        if (!isset($options['fieldList'])) {
+            $entity->set($properties);
+            $entity->errors($errors);
+            return $entity;
+        }
+
+        foreach ((array)$options['fieldList'] as $field) {
+            if (array_key_exists($field, $properties)) {
+                $entity->set($field, $properties[$field]);
+            }
+        }
+
+        $entity->errors($errors);
+        return $entity;
+    }
+
+    /**
+     * Returns the validation errors for a data set based on the passed options
+     *
+     * @param array $data The data to validate.
+     * @param array $options The options passed to this marshaller.
+     * @param bool $isNew Whether it is a new entity or one to be updated.
+     * @return array The list of validation errors.
+     * @throws \RuntimeException If no validator can be created.
+     */
+    protected function _validate($data, $options, $isNew)
+    {
+        if (!$options['validate']) {
+            return [];
+        }
+        if ($options['validate'] === true) {
+            $options['validate'] = $this->_endpoint->validator('default');
+        }
+        if (is_string($options['validate'])) {
+            $options['validate'] = $this->_endpoint->validator($options['validate']);
+        }
+        if (!is_object($options['validate'])) {
+            throw new RuntimeException(
+                sprintf('validate must be a boolean, a string or an object. Got %s.', gettype($options['validate']))
+            );
+        }
+
+        return $options['validate']->errors($data, $isNew);
+    }
+
+    /**
+     * Returns data and options prepared to validate and marshall.
+     *
+     * @param array $data The data to prepare.
+     * @param array $options The options passed to this marshaller.
+     * @return array An array containing prepared data and options.
+     */
+    protected function _prepareDataAndOptions($data, $options)
+    {
+        $options += ['validate' => true];
+
+        $endpointName = $this->_endpoint->alias();
+        if (isset($data[$endpointName])) {
+            $data = $data[$endpointName];
+        }
+
+        $data = new ArrayObject($data);
+        $options = new ArrayObject($options);
+        $this->_endpoint->dispatchEvent('Model.beforeMarshal', compact('data', 'options'));
+
+        return [(array)$data, (array)$options];
+    }
+
+    /**
+     * Hydrate many entities.
+     *
+     * ### Options:
+     *
+     * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     *   the accessible fields list in the entity will be used.
+     * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * @param array $data The data to hydrate.
+     * @param array $options List of options
+     * @return array An array of hydrated records.
+     * @see \Muffin\Webservice\Model\Endpoint::newEntities()
+     */
+    public function many(array $data, array $options = [])
+    {
+        $output = [];
+        foreach ($data as $record) {
+            if (!is_array($record)) {
+                continue;
+            }
+            $output[] = $this->one($record, $options);
+        }
+        return $output;
+    }
+
+    /**
+     * Merges `$data` into `$entity`.
+     *
+     * ### Options:
+     *
+     * * validate: Whether or not to validate data before hydrating the entities. Can
+     *   also be set to a string to use a specific validator. Defaults to true/default.
+     * * fieldList: A whitelist of fields to be assigned to the entity. If not present
+     *   the accessible fields list in the entity will be used.
+     * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
+     * data merged in
+     * @param array $data key value list of fields to be merged into the entity
+     * @param array $options List of options.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function merge(EntityInterface $entity, array $data, array $options = [])
+    {
+        list($data, $options) = $this->_prepareDataAndOptions($data, $options);
+
+        $isNew = $entity->isNew();
+        $keys = [];
+
+        if (!$isNew) {
+            $keys = $entity->extract((array)$this->_endpoint->primaryKey());
+        }
+
+        if (isset($options['accessibleFields'])) {
+            foreach ((array)$options['accessibleFields'] as $key => $value) {
+                $entity->accessible($key, $value);
+            }
+        }
+
+        $errors = $this->_validate($data + $keys, $options, $isNew);
+        $properties = [];
+        foreach ($data as $key => $value) {
+            if (!empty($errors[$key])) {
+                continue;
+            }
+
+            $properties[$key] = $value;
+        }
+
+        if (!isset($options['fieldList'])) {
+            $entity->set($properties);
+            $entity->errors($errors);
+
+            return $entity;
+        }
+
+        foreach ((array)$options['fieldList'] as $field) {
+            if (array_key_exists($field, $properties)) {
+                $entity->set($field, $properties[$field]);
+            }
+        }
+
+        $entity->errors($errors);
+        return $entity;
+    }
+
+    /**
+     * Merges each of the elements from `$data` into each of the entities in `$entities`.
+     *
+     * Records in `$data` are matched against the entities using the primary key
+     * column. Entries in `$entities` that cannot be matched to any record in
+     * `$data` will be discarded. Records in `$data` that could not be matched will
+     * be marshalled as a new entity.
+     *
+     * ### Options:
+     *
+     * - fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     *   the accessible fields list in the entity will be used.
+     * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * @param array|\Traversable $entities the entities that will get the
+     *   data merged in
+     * @param array $data list of arrays to be merged into the entities
+     * @param array $options List of options.
+     * @return array
+     */
+    public function mergeMany($entities, array $data, array $options = [])
+    {
+        $primary = (array)$this->_endpoint->primaryKey();
+
+        $indexed = (new Collection($data))
+            ->groupBy(function ($el) use ($primary) {
+                $keys = [];
+                foreach ($primary as $key) {
+                    $keys[] = isset($el[$key]) ? $el[$key] : '';
+                }
+                return implode(';', $keys);
+            })
+            ->map(function ($element, $key) {
+                return $key === '' ? $element : $element[0];
+            })
+            ->toArray();
+
+        $new = isset($indexed[null]) ? $indexed[null] : [];
+        unset($indexed[null]);
+        $output = [];
+
+        foreach ($entities as $entity) {
+            if (!($entity instanceof EntityInterface)) {
+                continue;
+            }
+
+            $key = implode(';', $entity->extract($primary));
+            if ($key === null || !isset($indexed[$key])) {
+                continue;
+            }
+
+            $output[] = $this->merge($entity, $indexed[$key], $options);
+            unset($indexed[$key]);
+        }
+
+        foreach ((new Collection($indexed))->append($new) as $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            $output[] = $this->one($value, $options);
+        }
+
+        return $output;
+    }
+}

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -8,12 +8,15 @@ use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Network\Exception\NotImplementedException;
 use Cake\Utility\Inflector;
+use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Exception\MissingResourceClassException;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 use Muffin\Webservice\Query;
 
 class Endpoint implements RepositoryInterface
 {
+
+    protected $_connection;
 
     /**
      * The schema object containing a description of this endpoint fields
@@ -214,6 +217,10 @@ class Endpoint implements RepositoryInterface
         return $this->_resourceClass;
     }
 
+    /**
+     * @param null $connection
+     * @return AbstractDriver
+     */
     public function connection($connection = null)
     {
         if ($connection === null) {

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -14,6 +14,11 @@ use Muffin\Webservice\Exception\UnexpectedDriverException;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 
+/**
+ * The table equivalent of a webservice endpoint
+ *
+ * @package Muffin\Webservice\Model
+ */
 class Endpoint implements RepositoryInterface
 {
 
@@ -33,6 +38,11 @@ class Endpoint implements RepositoryInterface
      */
     protected $_resourceClass;
 
+    /**
+     * The name of the endpoint to contact
+     *
+     * @var string
+     */
     protected $_endpoint;
 
     /**
@@ -50,9 +60,17 @@ class Endpoint implements RepositoryInterface
     protected $_displayField;
 
     /**
+     * The webservice instance to call
+     *
      * @var \Muffin\Webservice\Webservice\WebserviceInterface
      */
     protected $_webservice;
+
+    /**
+     * The alias to use for the endpoint
+     *
+     * @var string
+     */
     protected $_alias;
 
     /**
@@ -60,19 +78,13 @@ class Endpoint implements RepositoryInterface
      *
      * The $config array understands the following keys:
      *
-     * - endpoint: Name of the endpoint to represent
      * - alias: Alias to be assigned to this endpoint (default to endpoint name)
      * - connection: The connection instance to use
+     * - endpoint: Name of the endpoint to represent
      * - resourceClass: The fully namespaced class name of the resource class that will
      *   represent rows in this endpoint.
      * - schema: A \Muffin\Webservice\Schema object or an array that can be
      *   passed to it.
-     * - eventManager: An instance of an event manager to use for internal events
-     * - behaviors: A BehaviorRegistry. Generally not used outside of tests.
-     * - associations: An AssociationCollection instance.
-     * - validator: A Validator instance which is assigned as the "default"
-     *   validation set, or an associative array, where key is the name of the
-     *   validation set and value the Validator instance.
      *
      * @param array $config List of options for this endpoint
      */
@@ -177,6 +189,7 @@ class Endpoint implements RepositoryInterface
      * out of it and used as the schema for this endpoint.
      *
      * @param array|\Muffin\Webservice\Schema|null $schema New schema to be used for this endpoint
+     *
      * @return \Muffin\Webservice\Schema
      */
     public function schema($schema = null)
@@ -229,9 +242,9 @@ class Endpoint implements RepositoryInterface
     /**
      * Set the driver to use
      *
-     * @param AbstractDriver|null $connection The driver to use
+     * @param \Muffin\Webservice\AbstractDriver|null $connection The driver to use
      *
-     * @return AbstractDriver
+     * @return \Muffin\Webservice\AbstractDriver
      */
     public function connection($connection = null)
     {
@@ -245,9 +258,9 @@ class Endpoint implements RepositoryInterface
     /**
      * Returns an instance of the Webservice used
      *
-     * @param WebserviceInterface|string|null $webservice The webservice to use
+     * @param \Muffin\Webservice\Webservice\WebserviceInterface|string|null $webservice The webservice to use
      *
-     * @return $this|WebserviceInterface
+     * @return $this|\Muffin\Webservice\Webservice\WebserviceInterface
      */
     public function webservice($webservice = null)
     {
@@ -472,7 +485,7 @@ class Endpoint implements RepositoryInterface
      * @throws \Cake\Datasource\Exception\RecordNotFoundException if the record with such id
      * could not be found
      * @return \Cake\Datasource\EntityInterface
-     * @see RepositoryInterface::find()
+     * @see \Cake\Datasource\RepositoryInterface::find()
      */
     public function get($primaryKey, $options = [])
     {
@@ -521,7 +534,7 @@ class Endpoint implements RepositoryInterface
     /**
      * Creates a new Query instance for this repository
      *
-     * @return Query
+     * @return \Muffin\Webservice\Query
      */
     public function query()
     {
@@ -560,7 +573,7 @@ class Endpoint implements RepositoryInterface
      *
      * @return int Count Returns the affected rows.
      *
-     * @see Endpoint::delete()
+     * @see \\Muffin\Webservice\Endpoint::delete()
      */
     public function deleteAll($conditions)
     {

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -796,6 +796,10 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
             return false;
         }
 
+        if (($resource->isNew()) && ($result instanceof EntityInterface)) {
+            return $result;
+        }
+
         $className = get_class($resource);
         return new $className($resource->toArray(), [
             'markNew' => false,

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -11,8 +11,8 @@ use Cake\Utility\Inflector;
 use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Exception\MissingResourceClassException;
 use Muffin\Webservice\Exception\UnexpectedDriverException;
-use Muffin\Webservice\Webservice\WebserviceInterface;
 use Muffin\Webservice\Query;
+use Muffin\Webservice\Webservice\WebserviceInterface;
 
 class Endpoint implements RepositoryInterface
 {
@@ -227,7 +227,10 @@ class Endpoint implements RepositoryInterface
     }
 
     /**
-     * @param null $connection
+     * Set the driver to use
+     *
+     * @param AbstractDriver|null $connection The driver to use
+     *
      * @return AbstractDriver
      */
     public function connection($connection = null)
@@ -242,7 +245,8 @@ class Endpoint implements RepositoryInterface
     /**
      * Returns an instance of the Webservice used
      *
-     * @param WebserviceInterface|string|null $webservice
+     * @param WebserviceInterface|string|null $webservice The webservice to use
+     *
      * @return $this|WebserviceInterface
      */
     public function webservice($webservice = null)
@@ -553,8 +557,10 @@ class Endpoint implements RepositoryInterface
      *
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
+     *
      * @return int Count Returns the affected rows.
-     * @see RepositoryInterface::delete()
+     *
+     * @see Endpoint::delete()
      */
     public function deleteAll($conditions)
     {
@@ -566,6 +572,7 @@ class Endpoint implements RepositoryInterface
      * conditions.
      *
      * @param array|\ArrayAccess $conditions list of conditions to pass to the query
+     *
      * @return bool
      */
     public function exists($conditions)
@@ -580,6 +587,7 @@ class Endpoint implements RepositoryInterface
      *
      * @param \Cake\Datasource\EntityInterface $resource the resource to be saved
      * @param array|\ArrayAccess $options The options to use when saving.
+     *
      * @return \Cake\Datasource\EntityInterface|bool
      */
     public function save(EntityInterface $resource, $options = [])
@@ -648,6 +656,7 @@ class Endpoint implements RepositoryInterface
      *
      * @param array|null $data The data to build an resource with.
      * @param array $options A list of options for the object hydration.
+     *
      * @return \Cake\Datasource\EntityInterface
      */
     public function newEntity($data = null, array $options = [])
@@ -669,6 +678,7 @@ class Endpoint implements RepositoryInterface
      *
      * @param array $data The data to build an resource with.
      * @param array $options A list of options for the objects hydration.
+     *
      * @return array An array of hydrated records.
      */
     public function newEntities(array $data, array $options = [])
@@ -691,6 +701,7 @@ class Endpoint implements RepositoryInterface
      * data merged in
      * @param array $data key value list of fields to be merged into the resource
      * @param array $options A list of options for the object hydration.
+     *
      * @return \Cake\Datasource\EntityInterface
      */
     public function patchEntity(EntityInterface $resource, array $data, array $options = [])
@@ -714,6 +725,7 @@ class Endpoint implements RepositoryInterface
      * data merged in
      * @param array $data list of arrays to be merged into the entities
      * @param array $options A list of options for the objects hydration.
+     *
      * @return array
      */
     public function patchEntities($entities, array $data, array $options = [])
@@ -728,6 +740,7 @@ class Endpoint implements RepositoryInterface
      * @param string $type name of the finder to be called
      * @param \Muffin\Webservice\Query $query The query object to apply the finder options to
      * @param array $options List of options to pass to the finder
+     *
      * @return \Muffin\Webservice\Query
      */
     public function callFinder($type, Query $query, array $options = [])
@@ -782,6 +795,16 @@ class Endpoint implements RepositoryInterface
         return $options;
     }
 
+    /**
+     * Get the default connection name.
+     *
+     * This method is used to get the fallback connection name if an
+     * instance is created through the EndpointRegistry without a connection.
+     *
+     * @return string
+     *
+     * @see \Muffin\Webservice\Model\EndpointRegistry::get()
+     */
     public static function defaultConnectionName()
     {
         $namespaceParts = explode('\\', get_called_class());
@@ -790,6 +813,11 @@ class Endpoint implements RepositoryInterface
         return Inflector::underscore(current($plugin));
     }
 
+    /**
+     * Returns a handy representation of this endpoint
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -10,6 +10,7 @@ use Cake\Network\Exception\NotImplementedException;
 use Cake\Utility\Inflector;
 use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Exception\MissingResourceClassException;
+use Muffin\Webservice\Exception\UnexpectedDriverException;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 use Muffin\Webservice\Query;
 
@@ -247,7 +248,12 @@ class Endpoint implements RepositoryInterface
                 $webservice = $this->endpoint();
             }
 
-            $this->_webservice = $this->connection()->webservice($webservice);
+            $connection = $this->connection();
+            if (!$connection) {
+                throw new UnexpectedDriverException(__('No connection has been defined for this endpoint'));
+            }
+
+            $this->_webservice = $connection->webservice($webservice);
 
             return $this->_webservice;
         }
@@ -285,7 +291,11 @@ class Endpoint implements RepositoryInterface
             $this->_primaryKey = $key;
         }
         if ($this->_primaryKey === null) {
-            $key = (array)$this->schema()->primaryKey();
+            $schema = $this->schema();
+            if (!$schema) {
+                throw new UnexpectedDriverException(__('No schema has been defined for this endpoint'));
+            }
+            $key = (array)$schema->primaryKey();
             if (count($key) === 1) {
                 $key = $key[0];
             }
@@ -306,9 +316,13 @@ class Endpoint implements RepositoryInterface
             $this->_displayField = $key;
         }
         if ($this->_displayField === null) {
-            $schema = $this->schema();
             $primary = (array)$this->primaryKey();
             $this->_displayField = array_shift($primary);
+
+            $schema = $this->schema();
+            if (!$schema) {
+                throw new UnexpectedDriverException(__('No schema has been defined for this endpoint'));
+            }
             if ($schema->column('title')) {
                 $this->_displayField = 'title';
             }

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -157,6 +157,8 @@ class Endpoint implements RepositoryInterface
         if ($this->_endpoint === null) {
             $endpoint = namespaceSplit(get_class($this));
             $endpoint = substr(end($endpoint), 0, -8);
+
+            // In case someone constructs the Endpoint class directly
             if (empty($endpoint)) {
                 $endpoint = $this->alias();
             }
@@ -238,6 +240,8 @@ class Endpoint implements RepositoryInterface
     }
 
     /**
+     * Returns an instance of the Webservice used
+     *
      * @param WebserviceInterface|string|null $webservice
      * @return $this|WebserviceInterface
      */

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -564,7 +564,7 @@ class Endpoint implements RepositoryInterface
      */
     public function deleteAll($conditions)
     {
-        // TODO: Implement deleteAll() method.
+        return $this->query()->delete()->where($conditions)->execute();
     }
 
     /**
@@ -641,49 +641,29 @@ class Endpoint implements RepositoryInterface
     }
 
     /**
-     * Create a new resource + associated entities from an array.
+     * {@inheritDoc}
      *
-     * This is most useful when hydrating request data back into entities.
-     * For example, in your controller code:
-     *
-     * ```
-     * $article = $this->Articles->newEntity($this->request->data());
-     * ```
-     *
-     * The hydrated resource will correctly do an insert/update based
-     * on the primary key data existing in the webservice when the resource
-     * is saved. Until the resource is saved, it will be a detached record.
-     *
-     * @param array|null $data The data to build an resource with.
-     * @param array $options A list of options for the object hydration.
-     *
-     * @return \Cake\Datasource\EntityInterface
+     * @return \Muffin\Webservice\Model\Resource
      */
     public function newEntity($data = null, array $options = [])
     {
-        // TODO: Implement newEntity() method.
+        $resourceClass = $this->resourceClass();
+
+        return new $resourceClass($data, $options);
     }
 
     /**
-     * Create a list of entities + associated entities from an array.
-     *
-     * This is most useful when hydrating request data back into entities.
-     * For example, in your controller code:
-     *
-     * ```
-     * $articles = $this->Articles->newEntities($this->request->data());
-     * ```
-     *
-     * The hydrated entities can then be iterated and saved.
-     *
-     * @param array $data The data to build an resource with.
-     * @param array $options A list of options for the objects hydration.
-     *
-     * @return array An array of hydrated records.
+     * {@inheritDoc}
      */
     public function newEntities(array $data, array $options = [])
     {
-        // TODO: Implement newEntities() method.
+        $resources = [];
+
+        foreach ($data as $resourceData) {
+            $resources[] = $this->newEntity($resourceData, $options);
+        }
+
+        return $resources;
     }
 
     /**

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -682,7 +682,7 @@ class Endpoint implements RepositoryInterface
      * @param array $data key value list of fields to be merged into the resource
      * @param array $options A list of options for the object hydration.
      *
-     * @return \Cake\Datasource\EntityInterface
+     * @return void
      */
     public function patchEntity(EntityInterface $resource, array $data, array $options = [])
     {
@@ -706,7 +706,7 @@ class Endpoint implements RepositoryInterface
      * @param array $data list of arrays to be merged into the entities
      * @param array $options A list of options for the objects hydration.
      *
-     * @return array
+     * @return void
      */
     public function patchEntities($entities, array $data, array $options = [])
     {

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -80,11 +80,17 @@ class Endpoint implements RepositoryInterface
         if (!empty($config['alias'])) {
             $this->alias($config['alias']);
         }
+        if (!empty($config['connection'])) {
+            $this->connection($config['connection']);
+        }
+        if (!empty($config['displayField'])) {
+            $this->displayField($config['displayField']);
+        }
         if (!empty($config['endpoint'])) {
             $this->endpoint($config['endpoint']);
         }
-        if (!empty($config['connection'])) {
-            $this->connection($config['connection']);
+        if (!empty($config['primaryKey'])) {
+            $this->primaryKey($config['primaryKey']);
         }
         if (!empty($config['schema'])) {
             $this->schema($config['schema']);

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -10,7 +10,7 @@ use Cake\Network\Exception\NotImplementedException;
 use Cake\Utility\Inflector;
 use Muffin\Webservice\Exception\MissingResourceClassException;
 use Muffin\Webservice\Webservice\WebserviceInterface;
-use Muffin\Webservice\WebserviceQuery;
+use Muffin\Webservice\Query;
 
 class Endpoint implements RepositoryInterface
 {
@@ -317,7 +317,7 @@ class Endpoint implements RepositoryInterface
      *
      * @param string $type the type of query to perform
      * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
-     * @return \Muffin\Webservice\WebserviceQuery
+     * @return \Muffin\Webservice\Query
      */
     public function find($type = 'all', $options = [])
     {
@@ -331,11 +331,11 @@ class Endpoint implements RepositoryInterface
      * By default findAll() applies no conditions, you
      * can override this method in subclasses to modify how `find('all')` works.
      *
-     * @param \Muffin\Webservice\WebserviceQuery $query The query to find with
+     * @param \Muffin\Webservice\Query $query The query to find with
      * @param array $options The options to use for the find
-     * @return \Muffin\Webservice\WebserviceQuery The query builder
+     * @return \Muffin\Webservice\Query The query builder
      */
-    public function findAll(WebserviceQuery $query, array $options)
+    public function findAll(Query $query, array $options)
     {
         return $query;
     }
@@ -393,11 +393,11 @@ class Endpoint implements RepositoryInterface
      * ]
      * ```
      *
-     * @param \Muffin\Webservice\WebserviceQuery $query The query to find with
+     * @param \Muffin\Webservice\Query $query The query to find with
      * @param array $options The options for the find
-     * @return \Muffin\Webservice\WebserviceQuery The query builder
+     * @return \Muffin\Webservice\Query The query builder
      */
-    public function findList(WebserviceQuery $query, array $options)
+    public function findList(Query $query, array $options)
     {
         $options += [
             'keyField' => $this->primaryKey(),
@@ -492,11 +492,11 @@ class Endpoint implements RepositoryInterface
     /**
      * Creates a new Query instance for this repository
      *
-     * @return WebserviceQuery
+     * @return Query
      */
     public function query()
     {
-        return new WebserviceQuery($this->webservice(), $this);
+        return new Query($this->webservice(), $this);
     }
 
     /**
@@ -671,11 +671,11 @@ class Endpoint implements RepositoryInterface
      * if no query is passed a new one will be created and returned
      *
      * @param string $type name of the finder to be called
-     * @param \Muffin\Webservice\WebserviceQuery $query The query object to apply the finder options to
+     * @param \Muffin\Webservice\Query $query The query object to apply the finder options to
      * @param array $options List of options to pass to the finder
-     * @return \Muffin\Webservice\WebserviceQuery
+     * @return \Muffin\Webservice\Query
      */
-    public function callFinder($type, WebserviceQuery $query, array $options = [])
+    public function callFinder($type, Query $query, array $options = [])
     {
         $query->applyOptions($options);
         $options = $query->getOptions();

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -981,7 +981,7 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
     }
 
     /**
-     * Merges the passed `$data` into `$resource` respecting the accessible
+     * Merges the passed `$data` into `$entity` respecting the accessible
      * fields configured on the resource. Returns the same resource after being
      * altered.
      *
@@ -991,7 +991,7 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
      * $article = $this->Articles->patchEntity($article, $this->request->data());
      * ```
      *
-     * @param \Cake\Datasource\EntityInterface $resource the resource that will get the
+     * @param \Cake\Datasource\EntityInterface $entity the resource that will get the
      * data merged in
      * @param array $data key value list of fields to be merged into the resource
      * @param array $options A list of options for the object hydration.

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -1,0 +1,747 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+use Cake\Core\App;
+use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\InvalidPrimaryKeyException;
+use Cake\Datasource\RepositoryInterface;
+use Cake\Network\Exception\NotImplementedException;
+use Cake\Utility\Inflector;
+use Muffin\Webservice\Exception\MissingResourceClassException;
+use Muffin\Webservice\Webservice\WebserviceInterface;
+use Muffin\Webservice\WebserviceQuery;
+
+class Endpoint implements RepositoryInterface
+{
+
+    /**
+     * The schema object containing a description of this endpoint fields
+     *
+     * @var \Muffin\Webservice\Schema
+     */
+    protected $_schema;
+
+    /**
+     * The name of the class that represent a single resource for this endpoint
+     *
+     * @var string
+     */
+    protected $_resourceClass;
+
+    protected $_endpoint;
+
+    /**
+     * The name of the field that represents the primary key in the endpoint
+     *
+     * @var string|array
+     */
+    protected $_primaryKey;
+
+    /**
+     * The name of the field that represents a human readable representation of a row
+     *
+     * @var string
+     */
+    protected $_displayField;
+
+    /**
+     * @var \Muffin\Webservice\Webservice\WebserviceInterface
+     */
+    protected $_webservice;
+    protected $_alias;
+
+    /**
+     * Initializes a new instance
+     *
+     * The $config array understands the following keys:
+     *
+     * - endpoint: Name of the endpoint to represent
+     * - alias: Alias to be assigned to this endpoint (default to endpoint name)
+     * - connection: The connection instance to use
+     * - resourceClass: The fully namespaced class name of the resource class that will
+     *   represent rows in this endpoint.
+     * - schema: A \Muffin\Webservice\Schema object or an array that can be
+     *   passed to it.
+     * - eventManager: An instance of an event manager to use for internal events
+     * - behaviors: A BehaviorRegistry. Generally not used outside of tests.
+     * - associations: An AssociationCollection instance.
+     * - validator: A Validator instance which is assigned as the "default"
+     *   validation set, or an associative array, where key is the name of the
+     *   validation set and value the Validator instance.
+     *
+     * @param array $config List of options for this endpoint
+     */
+    public function __construct(array $config = [])
+    {
+        if (!empty($config['alias'])) {
+            $this->alias($config['alias']);
+        }
+        if (!empty($config['endpoint'])) {
+            $this->endpoint($config['endpoint']);
+        }
+        if (!empty($config['connection'])) {
+            $this->connection($config['connection']);
+        }
+        if (!empty($config['schema'])) {
+            $this->schema($config['schema']);
+        }
+        if (!empty($config['resourceClass'])) {
+            $this->resourceClass($config['resourceClass']);
+        }
+
+        $this->initialize($config);
+    }
+
+
+    /**
+     * Initialize a endpoint instance. Called after the constructor.
+     *
+     * You can use this method to define associations, attach behaviors
+     * define validation and do any other initialization logic you need.
+     *
+     * ```
+     *  public function initialize(array $config)
+     *  {
+     *      $this->belongsTo('Users');
+     *      $this->belongsToMany('Tagging.Tags');
+     *      $this->primaryKey('something_else');
+     *  }
+     * ```
+     *
+     * @param array $config Configuration options passed to the constructor
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+    }
+
+    /**
+     * Returns the endpoint alias or sets a new one
+     *
+     * @param string|null $alias the new endpoint alias
+     * @return string
+     */
+    public function alias($alias = null)
+    {
+        if ($alias === null) {
+            return $this->_alias;
+        }
+
+        $this->_alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * Returns the endpoint name or sets a new one
+     *
+     * @param string|null $endpoint the new endpoint name
+     * @return string
+     */
+    public function endpoint($endpoint = null)
+    {
+        if ($endpoint !== null) {
+            $this->_endpoint = $endpoint;
+        }
+        if ($this->_endpoint === null) {
+            $endpoint = namespaceSplit(get_class($this));
+            $endpoint = substr(end($endpoint), 0, -8);
+            if (empty($endpoint)) {
+                $endpoint = $this->alias();
+            }
+            $this->_endpoint = Inflector::underscore($endpoint);
+        }
+        return $this->_endpoint;
+    }
+
+    /**
+     * Returns the schema table object describing this endpoint's properties.
+     *
+     * If an \Muffin\Webservice\Schema is passed, it will be used for this endpoint
+     * instead of the default one.
+     *
+     * If an array is passed, a new \Muffin\Webservice\Schema will be constructed
+     * out of it and used as the schema for this endpoint.
+     *
+     * @param array|\Muffin\Webservice\Schema|null $schema New schema to be used for this endpoint
+     * @return \Muffin\Webservice\Schema
+     */
+    public function schema($schema = null)
+    {
+        if ($schema === null) {
+            return $this->_schema;
+        }
+
+        return $this->_schema = $schema;
+    }
+
+    /**
+     * Returns the class used to hydrate resources for this endpoint or sets
+     * a new one
+     *
+     * @param string|null $name the name of the class to use
+     * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
+     * @return string
+     */
+    public function resourceClass($name = null)
+    {
+        if ($name === null && !$this->_resourceClass) {
+            $default = '\Muffin\Webservice\Model\Resource';
+            $self = get_called_class();
+            $parts = explode('\\', $self);
+
+            if ($self === __CLASS__ || count($parts) < 3) {
+                return $this->_resourceClass = $default;
+            }
+
+            $alias = Inflector::singularize(substr(array_pop($parts), 0, -8));
+            $name = implode('\\', array_slice($parts, 0, -1)) . '\Resource\\' . $alias;
+            if (!class_exists($name)) {
+                return $this->_resourceClass = $default;
+            }
+        }
+
+        if ($name !== null) {
+            $class = App::className($name, 'Model/Resource');
+            $this->_resourceClass = $class;
+        }
+
+        if (!$this->_resourceClass) {
+            throw new MissingResourceClassException([$name]);
+        }
+
+        return $this->_resourceClass;
+    }
+
+    public function connection($connection = null)
+    {
+        if ($connection === null) {
+            return $this->_connection;
+        }
+
+        return $this->_connection = $connection;
+    }
+
+    /**
+     * @param WebserviceInterface|string|null $webservice
+     * @return $this|WebserviceInterface
+     */
+    public function webservice($webservice = null)
+    {
+        if ((is_string($webservice)) || ($this->_webservice === null)) {
+            if ($webservice === null) {
+                $webservice = $this->endpoint();
+            }
+
+            $this->_webservice = $this->connection()->webservice($webservice);
+
+            return $this->_webservice;
+        }
+        if ($webservice === null) {
+            return $this->_webservice;
+        }
+
+        $this->_webservice = $webservice;
+
+        return $this;
+    }
+
+    /**
+     * Test to see if a Repository has a specific field/column.
+     *
+     * @param string $field The field to check for.
+     * @return bool True if the field exists, false if it does not.
+     */
+    public function hasField($field)
+    {
+        $schema = $this->schema();
+
+        return $schema->column($field) !== null;
+    }
+
+    /**
+     * Returns the primary key field name or sets a new one
+     *
+     * @param string|array|null $key sets a new name to be used as primary key
+     * @return string|array
+     */
+    public function primaryKey($key = null)
+    {
+        if ($key !== null) {
+            $this->_primaryKey = $key;
+        }
+        if ($this->_primaryKey === null) {
+            $key = (array)$this->schema()->primaryKey();
+            if (count($key) === 1) {
+                $key = $key[0];
+            }
+            $this->_primaryKey = $key;
+        }
+        return $this->_primaryKey;
+    }
+
+    /**
+     * Returns the display field or sets a new one
+     *
+     * @param string|null $key sets a new name to be used as display field
+     * @return string
+     */
+    public function displayField($key = null)
+    {
+        if ($key !== null) {
+            $this->_displayField = $key;
+        }
+        if ($this->_displayField === null) {
+            $schema = $this->schema();
+            $primary = (array)$this->primaryKey();
+            $this->_displayField = array_shift($primary);
+            if ($schema->column('title')) {
+                $this->_displayField = 'title';
+            }
+            if ($schema->column('name')) {
+                $this->_displayField = 'name';
+            }
+        }
+        return $this->_displayField;
+    }
+
+    /**
+     * Creates a new Query for this repository and applies some defaults based on the
+     * type of search that was selected.
+     *
+     * ### Model.beforeFind event
+     *
+     * Each find() will trigger a `Model.beforeFind` event for all attached
+     * listeners. Any listener can set a valid result set using $query
+     *
+     * @param string $type the type of query to perform
+     * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
+     * @return \Muffin\Webservice\WebserviceQuery
+     */
+    public function find($type = 'all', $options = [])
+    {
+        $query = $this->query()->read();
+        return $this->callFinder($type, $query, $options);
+    }
+
+    /**
+     * Returns the query as passed.
+     *
+     * By default findAll() applies no conditions, you
+     * can override this method in subclasses to modify how `find('all')` works.
+     *
+     * @param \Muffin\Webservice\WebserviceQuery $query The query to find with
+     * @param array $options The options to use for the find
+     * @return \Muffin\Webservice\WebserviceQuery The query builder
+     */
+    public function findAll(WebserviceQuery $query, array $options)
+    {
+        return $query;
+    }
+
+    /**
+     * Sets up a query object so results appear as an indexed array, useful for any
+     * place where you would want a list such as for populating input select boxes.
+     *
+     * When calling this finder, the fields passed are used to determine what should
+     * be used as the array key, value and optionally what to group the results by.
+     * By default the primary key for the model is used for the key, and the display
+     * field as value.
+     *
+     * The results of this finder will be in the following form:
+     *
+     * ```
+     * [
+     *  1 => 'value for id 1',
+     *  2 => 'value for id 2',
+     *  4 => 'value for id 4'
+     * ]
+     * ```
+     *
+     * You can specify which property will be used as the key and which as value
+     * by using the `$options` array, when not specified, it will use the results
+     * of calling `primaryKey` and `displayField` respectively in this endpoint:
+     *
+     * ```
+     * $endpoint->find('list', [
+     *  'keyField' => 'name',
+     *  'valueField' => 'age'
+     * ]);
+     * ```
+     *
+     * Results can be put together in bigger groups when they share a property, you
+     * can customize the property to use for grouping by setting `groupField`:
+     *
+     * ```
+     * $endpoint->find('list', [
+     *  'groupField' => 'category_id',
+     * ]);
+     * ```
+     *
+     * When using a `groupField` results will be returned in this format:
+     *
+     * ```
+     * [
+     *  'group_1' => [
+     *      1 => 'value for id 1',
+     *      2 => 'value for id 2',
+     *  ]
+     *  'group_2' => [
+     *      4 => 'value for id 4'
+     *  ]
+     * ]
+     * ```
+     *
+     * @param \Muffin\Webservice\WebserviceQuery $query The query to find with
+     * @param array $options The options for the find
+     * @return \Muffin\Webservice\WebserviceQuery The query builder
+     */
+    public function findList(WebserviceQuery $query, array $options)
+    {
+        $options += [
+            'keyField' => $this->primaryKey(),
+            'valueField' => $this->displayField(),
+            'groupField' => null
+        ];
+
+        if (isset($options['idField'])) {
+            $options['keyField'] = $options['idField'];
+            unset($options['idField']);
+            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
+        }
+
+        $options = $this->_setFieldMatchers(
+            $options,
+            ['keyField', 'valueField', 'groupField']
+        );
+
+        return $query->formatResults(function ($results) use ($options) {
+            return $results->combine(
+                $options['keyField'],
+                $options['valueField'],
+                $options['groupField']
+            );
+        });
+    }
+
+    /**
+     * Returns a single record after finding it by its primary key, if no record is
+     * found this method throws an exception.
+     *
+     * ### Example:
+     *
+     * ```
+     * $id = 10;
+     * $article = $articles->get($id);
+     *
+     * $article = $articles->get($id, ['contain' => ['Comments]]);
+     * ```
+     *
+     * @param mixed $primaryKey primary key value to find
+     * @param array|\ArrayAccess $options options accepted by `Endpoint::find()`
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException if the record with such id
+     * could not be found
+     * @return \Cake\Datasource\EntityInterface
+     * @see RepositoryInterface::find()
+     */
+    public function get($primaryKey, $options = [])
+    {
+        $key = (array)$this->primaryKey();
+        $alias = $this->alias();
+        foreach ($key as $index => $keyname) {
+            $key[$index] = $keyname;
+        }
+        $primaryKey = (array)$primaryKey;
+        if (count($key) !== count($primaryKey)) {
+            $primaryKey = $primaryKey ?: [null];
+            $primaryKey = array_map(function ($key) {
+                return var_export($key, true);
+            }, $primaryKey);
+
+            throw new InvalidPrimaryKeyException(sprintf(
+                'Record not found in endpoint "%s" with primary key [%s]',
+                $this->webservice(),
+                implode($primaryKey, ', ')
+            ));
+        }
+        $conditions = array_combine($key, $primaryKey);
+
+        $cacheConfig = isset($options['cache']) ? $options['cache'] : false;
+        $cacheKey = isset($options['key']) ? $options['key'] : false;
+        $finder = isset($options['finder']) ? $options['finder'] : 'all';
+        unset($options['key'], $options['cache'], $options['finder']);
+
+        $query = $this->find($finder, $options)->conditions($conditions);
+
+        if ($cacheConfig) {
+            if (!$cacheKey) {
+                $cacheKey = sprintf(
+                    "get:%s.%s%s",
+                    $this->connection()->configName(),
+                    $this->webservice(),
+                    json_encode($primaryKey)
+                );
+            }
+            $query->cache($cacheKey, $cacheConfig);
+        }
+
+        return $query->firstOrFail();
+    }
+
+    /**
+     * Creates a new Query instance for this repository
+     *
+     * @return WebserviceQuery
+     */
+    public function query()
+    {
+        return new WebserviceQuery($this->webservice(), $this);
+    }
+
+    /**
+     * Update all matching records.
+     *
+     * Sets the $fields to the provided values based on $conditions.
+     * This method will *not* trigger beforeSave/afterSave events. If you need those
+     * first load a collection of records and update them.
+     *
+     * @param array $fields A hash of field => new value.
+     * @param mixed $conditions Conditions to be used, accepts anything Query::where()
+     * can take.
+     * @return int Count Returns the affected rows.
+     */
+    public function updateAll($fields, $conditions)
+    {
+        // TODO: Implement updateAll() method.
+    }
+
+    /**
+     * Delete all matching records.
+     *
+     * Deletes all records matching the provided conditions.
+     *
+     * This method will *not* trigger beforeDelete/afterDelete events. If you
+     * need those first load a collection of records and delete them.
+     *
+     * This method will *not* execute on associations' `cascade` attribute.
+     *
+     * @param mixed $conditions Conditions to be used, accepts anything Query::where()
+     * can take.
+     * @return int Count Returns the affected rows.
+     * @see RepositoryInterface::delete()
+     */
+    public function deleteAll($conditions)
+    {
+        // TODO: Implement deleteAll() method.
+    }
+
+    /**
+     * Returns true if there is any record in this repository matching the specified
+     * conditions.
+     *
+     * @param array|\ArrayAccess $conditions list of conditions to pass to the query
+     * @return bool
+     */
+    public function exists($conditions)
+    {
+        // TODO: Implement exists() method.
+    }
+
+    /**
+     * Persists an resource based on the fields that are marked as dirty and
+     * returns the same resource after a successful save or false in case
+     * of any error.
+     *
+     * @param \Cake\Datasource\EntityInterface $resource the resource to be saved
+     * @param array|\ArrayAccess $options The options to use when saving.
+     * @return \Cake\Datasource\EntityInterface|bool
+     */
+    public function save(EntityInterface $resource, $options = [])
+    {
+        // TODO: Implement save() method.
+    }
+
+    /**
+     * Delete a single resource.
+     *
+     * Deletes an resource and possibly related associations from the webservice
+     * based on the 'dependent' option used when defining the association.
+     *
+     * @param \Cake\Datasource\EntityInterface $resource The resource to remove.
+     * @param array|\ArrayAccess $options The options for the delete.
+     * @return bool success
+     */
+    public function delete(EntityInterface $resource, $options = [])
+    {
+        // TODO: Implement delete() method.
+    }
+
+    /**
+     * Create a new resource + associated entities from an array.
+     *
+     * This is most useful when hydrating request data back into entities.
+     * For example, in your controller code:
+     *
+     * ```
+     * $article = $this->Articles->newEntity($this->request->data());
+     * ```
+     *
+     * The hydrated resource will correctly do an insert/update based
+     * on the primary key data existing in the webservice when the resource
+     * is saved. Until the resource is saved, it will be a detached record.
+     *
+     * @param array|null $data The data to build an resource with.
+     * @param array $options A list of options for the object hydration.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function newEntity($data = null, array $options = [])
+    {
+        // TODO: Implement newEntity() method.
+    }
+
+    /**
+     * Create a list of entities + associated entities from an array.
+     *
+     * This is most useful when hydrating request data back into entities.
+     * For example, in your controller code:
+     *
+     * ```
+     * $articles = $this->Articles->newEntities($this->request->data());
+     * ```
+     *
+     * The hydrated entities can then be iterated and saved.
+     *
+     * @param array $data The data to build an resource with.
+     * @param array $options A list of options for the objects hydration.
+     * @return array An array of hydrated records.
+     */
+    public function newEntities(array $data, array $options = [])
+    {
+        // TODO: Implement newEntities() method.
+    }
+
+    /**
+     * Merges the passed `$data` into `$resource` respecting the accessible
+     * fields configured on the resource. Returns the same resource after being
+     * altered.
+     *
+     * This is most useful when editing an existing resource using request data:
+     *
+     * ```
+     * $article = $this->Articles->patchEntity($article, $this->request->data());
+     * ```
+     *
+     * @param \Cake\Datasource\EntityInterface $resource the resource that will get the
+     * data merged in
+     * @param array $data key value list of fields to be merged into the resource
+     * @param array $options A list of options for the object hydration.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function patchEntity(EntityInterface $resource, array $data, array $options = [])
+    {
+        throw new NotImplementedException('patchEntity has not been implemented yet');
+    }
+
+    /**
+     * Merges each of the elements passed in `$data` into the entities
+     * found in `$entities` respecting the accessible fields configured on the entities.
+     * Merging is done by matching the primary key in each of the elements in `$data`
+     * and `$entities`.
+     *
+     * This is most useful when editing a list of existing entities using request data:
+     *
+     * ```
+     * $article = $this->Articles->patchEntities($articles, $this->request->data());
+     * ```
+     *
+     * @param array|\Traversable $entities the entities that will get the
+     * data merged in
+     * @param array $data list of arrays to be merged into the entities
+     * @param array $options A list of options for the objects hydration.
+     * @return array
+     */
+    public function patchEntities($entities, array $data, array $options = [])
+    {
+        throw new NotImplementedException('patchEntities has not been implemented yet');
+    }
+
+    /**
+     * Calls a finder method directly and applies it to the passed query,
+     * if no query is passed a new one will be created and returned
+     *
+     * @param string $type name of the finder to be called
+     * @param \Muffin\Webservice\WebserviceQuery $query The query object to apply the finder options to
+     * @param array $options List of options to pass to the finder
+     * @return \Muffin\Webservice\WebserviceQuery
+     */
+    public function callFinder($type, WebserviceQuery $query, array $options = [])
+    {
+        $query->applyOptions($options);
+        $options = $query->getOptions();
+        $finder = 'find' . $type;
+        if (method_exists($this, $finder)) {
+            return $this->{$finder}($query, $options);
+        }
+
+        throw new \BadMethodCallException(
+            sprintf('Unknown finder method "%s"', $type)
+        );
+    }
+
+    /**
+     * Out of an options array, check if the keys described in `$keys` are arrays
+     * and change the values for closures that will concatenate the each of the
+     * properties in the value array when passed a row.
+     *
+     * This is an auxiliary function used for result formatters that can accept
+     * composite keys when comparing values.
+     *
+     * @param array $options the original options passed to a finder
+     * @param array $keys the keys to check in $options to build matchers from
+     * the associated value
+     * @return array
+     */
+    protected function _setFieldMatchers($options, $keys)
+    {
+        foreach ($keys as $field) {
+            if (!is_array($options[$field])) {
+                continue;
+            }
+
+            if (count($options[$field]) === 1) {
+                $options[$field] = current($options[$field]);
+                continue;
+            }
+
+            $fields = $options[$field];
+            $options[$field] = function ($row) use ($fields) {
+                $matches = [];
+                foreach ($fields as $field) {
+                    $matches[] = $row[$field];
+                }
+                return implode(';', $matches);
+            };
+        }
+
+        return $options;
+    }
+
+    public static function defaultConnectionName()
+    {
+        $namespaceParts = explode('\\', get_called_class());
+        $plugin = array_slice(array_reverse($namespaceParts), 3, 2);
+
+        return Inflector::underscore(current($plugin));
+    }
+
+    public function __debugInfo()
+    {
+        return [
+            'alias' => $this->alias(),
+            'connection' => $this->connection(),
+            'endpoint' => $this->endpoint(),
+            'resourceClass' => $this->resourceClass()
+        ];
+    }
+}

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -493,7 +493,7 @@ class Endpoint implements RepositoryInterface
         $finder = isset($options['finder']) ? $options['finder'] : 'all';
         unset($options['key'], $options['cache'], $options['finder']);
 
-        $query = $this->find($finder, $options)->conditions($conditions);
+        $query = $this->find($finder, $options)->where($conditions);
 
         if ($cacheConfig) {
             if (!$cacheKey) {

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -432,12 +432,6 @@ class Endpoint implements RepositoryInterface
             'groupField' => null
         ];
 
-        if (isset($options['idField'])) {
-            $options['keyField'] = $options['idField'];
-            unset($options['idField']);
-            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
-        }
-
         $options = $this->_setFieldMatchers(
             $options,
             ['keyField', 'valueField', 'groupField']

--- a/src/Model/EndpointRegistry.php
+++ b/src/Model/EndpointRegistry.php
@@ -28,6 +28,7 @@ class EndpointRegistry
      *
      * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the endpoint with.
+     *
      * @return \Muffin\Webservice\Model\Endpoint
      */
     public static function get($alias, array $options = [])
@@ -62,7 +63,7 @@ class EndpointRegistry
         if (empty($options['connection'])) {
             if ($options['className'] !== 'Muffin\Webservice\Model\Endpoint') {
                 $connectionName = $options['className']::defaultConnectionName();
-            } else{
+            } else {
                 $pluginParts = explode('/', pluginSplit($alias)[0]);
 
                 $connectionName = Inflector::underscore(end($pluginParts));
@@ -81,6 +82,7 @@ class EndpointRegistry
      * Wrapper for creating endpoint instances
      *
      * @param array $options The alias to check for.
+     *
      * @return \Muffin\Webservice\Model\Endpoint
      */
     protected static function _create(array $options)

--- a/src/Model/EndpointRegistry.php
+++ b/src/Model/EndpointRegistry.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+use Cake\Core\App;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Inflector;
+use Muffin\Webservice\AbstractDriver;
+use RuntimeException;
+
+class EndpointRegistry
+{
+
+    /**
+     * Instances that belong to the registry.
+     *
+     * @var array
+     */
+    protected static $_instances = [];
+
+    /**
+     * @var array
+     */
+    protected static $_options = [];
+
+    /**
+     * Get a endpoint instance from the registry.
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the endpoint with.
+     * @return \Muffin\Webservice\Model\Endpoint
+     */
+    public static function get($alias, array $options = [])
+    {
+        if (isset(self::$_instances[$alias])) {
+            if (!empty($options) && self::$_options[$alias] !== $options) {
+                throw new RuntimeException(sprintf(
+                    'You cannot configure "%s", it already exists in the registry.',
+                    $alias
+                ));
+            }
+            return self::$_instances[$alias];
+        }
+
+        list(, $classAlias) = pluginSplit($alias);
+        $options = ['alias' => $classAlias] + $options;
+
+        if (empty($options['className'])) {
+            $options['className'] = Inflector::camelize($alias);
+        }
+        $className = App::className($options['className'], 'Model/Endpoint', 'Endpoint');
+        if ($className) {
+            $options['className'] = $className;
+        } else {
+            if (!isset($options['endpoint']) && strpos($options['className'], '\\') === false) {
+                list(, $endpoint) = pluginSplit($options['className']);
+                $options['endpoint'] = Inflector::underscore($endpoint);
+            }
+            $options['className'] = 'Muffin\Webservice\Model\Endpoint';
+        }
+
+        if (empty($options['connection'])) {
+            if ($options['className'] !== 'Muffin\Webservice\Model\Endpoint') {
+                $connectionName = $options['className']::defaultConnectionName();
+            } else{
+                $pluginParts = explode('/', pluginSplit($alias)[0]);
+
+                $connectionName = Inflector::underscore(end($pluginParts));
+            }
+
+            $options['connection'] = ConnectionManager::get($connectionName);
+        }
+
+        $options['registryAlias'] = $alias;
+        self::$_instances[$alias] = self::_create($options);
+
+        return self::$_instances[$alias];
+    }
+
+    /**
+     * Wrapper for creating endpoint instances
+     *
+     * @param array $options The alias to check for.
+     * @return \Muffin\Webservice\Model\Endpoint
+     */
+    protected static function _create(array $options)
+    {
+        return new $options['className']($options);
+    }
+}

--- a/src/Model/Resource.php
+++ b/src/Model/Resource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+use Cake\Datasource\EntityInterface;
+use Cake\Datasource\EntityTrait;
+
+class Resource implements EntityInterface
+{
+
+    use EntityTrait;
+
+    /**
+     * Initializes the internal properties of this resource out of the
+     * keys in an array. The following list of options can be used:
+     *
+     * - useSetters: whether use internal setters for properties or not
+     * - markClean: whether to mark all properties as clean after setting them
+     * - markNew: whether this instance has not yet been persisted
+     * - guard: whether to prevent inaccessible properties from being set (default: false)
+     * - source: A string representing the alias of the repository this resource came from
+     *
+     * ### Example:
+     *
+     * ```
+     *  $resource = new Resource(['id' => 1, 'name' => 'Andrew'])
+     * ```
+     *
+     * @param array $properties hash of properties to set in this resource
+     * @param array $options list of options to use when creating this resource
+     */
+    public function __construct(array $properties = [], array $options = [])
+    {
+        $options += [
+            'useSetters' => true,
+            'markClean' => false,
+            'markNew' => null,
+            'guard' => false,
+            'source' => null
+        ];
+        $this->_className = get_class($this);
+
+        if (!empty($options['source'])) {
+            $this->source($options['source']);
+        }
+
+        if ($options['markNew'] !== null) {
+            $this->isNew($options['markNew']);
+        }
+
+        if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
+            $this->_properties = $properties;
+            return;
+        }
+
+        if (!empty($properties)) {
+            $this->set($properties, [
+                'setter' => $options['useSetters'],
+                'guard' => $options['guard']
+            ]);
+        }
+
+        if ($options['markClean']) {
+            $this->clean();
+        }
+    }
+}

--- a/src/Model/ResourceBasedEntityInterface.php
+++ b/src/Model/ResourceBasedEntityInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+interface ResourceBasedEntityInterface
+{
+
+    public function applyResource(Resource $resource);
+
+    public static function createFromResource(Resource $resource, array $options = []);
+}

--- a/src/Model/ResourceBasedEntityInterface.php
+++ b/src/Model/ResourceBasedEntityInterface.php
@@ -5,7 +5,22 @@ namespace Muffin\Webservice\Model;
 interface ResourceBasedEntityInterface
 {
 
+    /**
+     * Apply the properties from a resource
+     *
+     * @param \Muffin\Webservice\Model\Resource $resource The resource to apply the properties from
+     *
+     * @return void
+     */
     public function applyResource(Resource $resource);
 
+    /**
+     * Creates a instance if the current entity with the values of a resouce
+     *
+     * @param \Muffin\Webservice\Model\Resource $resource The resource to apply the properties from
+     * @param array $options The options to pass to the constructor
+     *
+     * @return self
+     */
     public static function createFromResource(Resource $resource, array $options = []);
 }

--- a/src/Model/ResourceBasedEntityTrait.php
+++ b/src/Model/ResourceBasedEntityTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+trait ResourceBasedEntityTrait
+{
+
+    public static function createFromResource(Resource $resource, array $options = [])
+    {
+        $entity = new self();
+
+        $entity->applyResource($resource);
+
+        return $entity;
+    }
+
+    public function applyResource(Resource $resource)
+    {
+        $this->set($resource->toArray());
+    }
+}

--- a/src/Model/ResourceBasedEntityTrait.php
+++ b/src/Model/ResourceBasedEntityTrait.php
@@ -5,6 +5,11 @@ namespace Muffin\Webservice\Model;
 trait ResourceBasedEntityTrait
 {
 
+    public function applyResource(Resource $resource)
+    {
+        $this->set($resource->toArray());
+    }
+
     public static function createFromResource(Resource $resource, array $options = [])
     {
         $entity = new self();
@@ -12,10 +17,5 @@ trait ResourceBasedEntityTrait
         $entity->applyResource($resource);
 
         return $entity;
-    }
-
-    public function applyResource(Resource $resource)
-    {
-        $this->set($resource->toArray());
     }
 }

--- a/src/Model/ResourceBasedEntityTrait.php
+++ b/src/Model/ResourceBasedEntityTrait.php
@@ -5,11 +5,26 @@ namespace Muffin\Webservice\Model;
 trait ResourceBasedEntityTrait
 {
 
+    /**
+     * Apply the properties from a resource
+     *
+     * @param \Muffin\Webservice\Model\Resource $resource The resource to apply the properties from
+     *
+     * @return void
+     */
     public function applyResource(Resource $resource)
     {
         $this->set($resource->toArray());
     }
 
+    /**
+     * Creates a instance if the current entity with the values of a resouce
+     *
+     * @param \Muffin\Webservice\Model\Resource $resource The resource to apply the properties from
+     * @param array $options The options to pass to the constructor
+     *
+     * @return self
+     */
     public static function createFromResource(Resource $resource, array $options = [])
     {
         $entity = new self();

--- a/src/Query.php
+++ b/src/Query.php
@@ -3,13 +3,11 @@
 namespace Muffin\Webservice;
 
 use Cake\Datasource\QueryTrait;
-use Cake\Datasource\RepositoryInterface;
-use Cake\Error\Debugger;
 use Cake\Utility\Hash;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 
-class WebserviceQuery
+class Query
 {
 
     use QueryTrait;
@@ -126,7 +124,7 @@ class WebserviceQuery
      *
      * @internal This method is only for compatibility with some plugins
      *
-     * @return $this|array|WebserviceQuery
+     * @return $this|array|Query
      */
     public function where($conditions = null, $types = [], $overwrite = false)
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -254,6 +254,10 @@ class Query
         return $this->all()->first();
     }
 
+    public function execute()
+    {
+        return $this->_execute();
+    }
 
     /**
      * Executes this query and returns a traversable object containing the results
@@ -277,7 +281,7 @@ class Query
             'set' => $this->set(),
             'sort' => $this->order(),
             'extraOptions' => $this->getOptions(),
-            'conditions' => $this->conditions(),
+            'conditions' => $this->where(),
             'repository' => $this->endpoint(),
             'webservice' => $this->_webservice
         ];

--- a/src/Query.php
+++ b/src/Query.php
@@ -2,6 +2,7 @@
 
 namespace Muffin\Webservice;
 
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\QueryTrait;
 use Cake\Utility\Hash;
 use Muffin\Webservice\Model\Endpoint;
@@ -111,6 +112,25 @@ class Query
         $this->repository($endpoint);
 
         return $this;
+    }
+
+    /**
+     * Get the first result from the executing query or raise an exception.
+     *
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
+     *
+     * @return mixed The first result from the ResultSet.
+     */
+    public function firstOrFail()
+    {
+        $entity = $this->first();
+        if ($entity) {
+            return $entity;
+        }
+        throw new RecordNotFoundException(sprintf(
+            'Record not found in endpoint "%s"',
+            $this->repository()->endpoint()
+        ));
     }
 
     public function aliasField($field)

--- a/src/Query.php
+++ b/src/Query.php
@@ -517,7 +517,7 @@ class Query implements QueryInterface, IteratorAggregate
             'extraOptions' => $this->getOptions(),
             'conditions' => $this->where(),
             'repository' => $this->endpoint(),
-            'webservice' => $this->_webservice
+            'webservice' => $this->webservice()
         ];
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -158,9 +158,9 @@ class Query implements QueryInterface
     /**
      * Set the endpoint to be used
      *
-     * @param Endpoint|null $endpoint The endpoint to use
+     * @param \Muffin\Webservice\Model\Endpoint|null $endpoint The endpoint to use
      *
-     * @return Endpoint|$this
+     * @return \Muffin\Webservice\Model\Endpoint|$this
      */
     public function endpoint(Endpoint $endpoint = null)
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -128,6 +128,34 @@ class Query implements QueryInterface
     }
 
     /**
+     * Returns any data that was stored in the specified clause.
+     *
+     * - where: QueryExpression, returns null when not set
+     * - order: OrderByExpression, returns null when not set
+     * - limit: integer or QueryExpression, null when not set
+     * - offset: integer or QueryExpression, null when not set
+     *
+     * @param string $name name of the clause to be returned
+     *
+     * @return mixed
+     */
+    public function clause($name)
+    {
+        switch ($name) {
+            case 'limit':
+                return $this->_limit;
+            case 'offset':
+                return $this->_offset;
+            case 'order':
+                return $this->_order;
+            case 'where':
+                return $this->_conditions;
+        }
+
+        return null;
+    }
+
+    /**
      * Set the endpoint to be used
      *
      * @param Endpoint|null $endpoint The endpoint to use
@@ -176,9 +204,11 @@ class Query implements QueryInterface
      * Alias a field with the endpoint's current alias.
      *
      * @param string $field The field to alias.
+     * @param null $alias Not being used
+     *
      * @return string The field prefixed with the endpoint alias.
      */
-    public function aliasField($field)
+    public function aliasField($field, $alias = null)
     {
         return [$field => $field];
     }
@@ -192,7 +222,7 @@ class Query implements QueryInterface
      *
      * @return $this|array
      */
-    public function where(array $conditions = null, $types = [], $overwrite = false)
+    public function where($conditions = null, $types = [], $overwrite = false)
     {
         if ($conditions === null) {
             return $this->_conditions;
@@ -310,19 +340,15 @@ class Query implements QueryInterface
     }
 
     /**
-     * Set the order in which results should be
-     *
-     * @param array|null $fields The array of fields and their direction
-     *
-     * @return $this|array
+     * {@inheritDoc}
      */
-    public function order(array $fields = null)
+    public function order($fields, $overwrite = false)
     {
         if ($fields === null) {
             return $this->_order;
         }
 
-        $this->_order = $fields;
+        $this->_order = (!$overwrite) ? Hash::merge($this->_order, $fields) : $fields;
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -509,6 +509,7 @@ class Query implements QueryInterface, IteratorAggregate
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'action' => $this->action(),
             'formatters' => $this->_formatters,
+            'offset' => $this->clause('offset'),
             'page' => $this->page(),
             'limit' => $this->limit(),
             'set' => $this->set(),

--- a/src/Query.php
+++ b/src/Query.php
@@ -3,12 +3,13 @@
 namespace Muffin\Webservice;
 
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
 use Cake\Utility\Hash;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 
-class Query
+class Query implements QueryInterface
 {
 
     use QueryTrait;
@@ -53,6 +54,7 @@ class Query
     private $_page;
     private $_limit;
     private $_fields = [];
+    private $_offset = [];
     private $_order = [];
 
     /**
@@ -141,6 +143,14 @@ class Query
         $this->repository($endpoint);
 
         return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function find($finder, array $options = [])
+    {
+        return $this->repository()->callFinder($finder, $this, $options);
     }
 
     /**
@@ -285,6 +295,16 @@ class Query
         }
 
         $this->_fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offset($num)
+    {
+        $this->_offset = $num;
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -344,10 +344,6 @@ class Query implements QueryInterface
      */
     public function order($fields, $overwrite = false)
     {
-        if ($fields === null) {
-            return $this->clause('order');
-        }
-
         $this->_parts['order'] = (!$overwrite) ? Hash::merge($this->clause('order'), $fields) : $fields;
 
         return $this;
@@ -455,6 +451,7 @@ class Query implements QueryInterface
         return [
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'action' => $this->action(),
+            'formatters' => $this->_formatters,
             'page' => $this->page(),
             'limit' => $this->limit(),
             'set' => $this->set(),

--- a/src/Query.php
+++ b/src/Query.php
@@ -231,6 +231,10 @@ class Query
 
     public function count()
     {
+        if ($this->action() !== self::ACTION_READ) {
+            return false;
+        }
+
         if (!$this->_resultSet) {
             $this->_execute();
         }

--- a/src/Query.php
+++ b/src/Query.php
@@ -382,6 +382,11 @@ class Query implements QueryInterface
 
             unset($options['order']);
         }
+        if (isset($options['conditions'])) {
+            $this->where($options['conditions']);
+
+            unset($options['conditions']);
+        }
 
         $this->_options = Hash::merge($this->_options, $options);
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -289,9 +289,9 @@ class Query implements QueryInterface
     }
 
     /**
-     * Sets the number of records that should be retrieved from database,
+     * Sets the number of records that should be retrieved from the webservice,
      * accepts an integer or an expression object that evaluates to an integer.
-     * In some databases, this operation might not be supported or will require
+     * In some webservices, this operation might not be supported or will require
      * the query to be transformed in order to limit the result set size.
      *
      * ### Examples
@@ -437,9 +437,9 @@ class Query implements QueryInterface
     public function triggerBeforeFind()
     {
         if (!$this->_beforeFindFired && $this->action() === self::ACTION_READ) {
-            $table = $this->repository();
+            $endpoint = $this->repository();
             $this->_beforeFindFired = true;
-            $table->dispatchEvent('Model.beforeFind', [
+            $endpoint->dispatchEvent('Model.beforeFind', [
                 $this,
                 new ArrayObject($this->_options),
                 !$this->eagerLoaded()

--- a/src/Query.php
+++ b/src/Query.php
@@ -122,13 +122,17 @@ class Query
      * @param array $types
      * @param bool|false $overwrite
      *
-     * @internal This method is only for compatibility with some plugins
-     *
      * @return $this|array|Query
      */
     public function where($conditions = null, $types = [], $overwrite = false)
     {
-        return $this->conditions($conditions, !$overwrite);
+        if ($conditions === null) {
+            return $this->_conditions;
+        }
+
+        $this->_conditions = (!$overwrite) ? Hash::merge($this->_conditions, $conditions) : $conditions;
+
+        return $this;
     }
 
     public function action($action = null)
@@ -138,17 +142,6 @@ class Query
         }
 
         $this->_action = $action;
-
-        return $this;
-    }
-
-    public function conditions(array $conditions = null, $merge = true)
-    {
-        if ($conditions === null) {
-            return $this->_conditions;
-        }
-
-        $this->_conditions = ($merge) ? Hash::merge($this->_conditions, $conditions) : $conditions;
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -65,12 +65,23 @@ class Query
      */
     protected $_resultSet;
 
+    /**
+     * Construct the query
+     *
+     * @param WebserviceInterface $webservice The webservice to use
+     * @param Endpoint $endpoint The endpoint this is executed from
+     */
     public function __construct(WebserviceInterface $webservice, Endpoint $endpoint)
     {
         $this->_webservice = $webservice;
         $this->endpoint($endpoint);
     }
 
+    /**
+     * Mark the query as create
+     *
+     * @return $this
+     */
     public function create()
     {
         $this->action(self::ACTION_CREATE);
@@ -78,6 +89,11 @@ class Query
         return $this;
     }
 
+    /**
+     * Mark the query as read
+     *
+     * @return $this
+     */
     public function read()
     {
         $this->action(self::ACTION_READ);
@@ -85,6 +101,11 @@ class Query
         return $this;
     }
 
+    /**
+     * Mark the query as update
+     *
+     * @return $this
+     */
     public function update()
     {
         $this->action(self::ACTION_UPDATE);
@@ -92,6 +113,11 @@ class Query
         return $this;
     }
 
+    /**
+     * Mark the query as delete
+     *
+     * @return $this
+     */
     public function delete()
     {
         $this->action(self::ACTION_DELETE);
@@ -100,7 +126,10 @@ class Query
     }
 
     /**
-     * @param Endpoint|null $endpoint
+     * Set the endpoint to be used
+     *
+     * @param Endpoint|null $endpoint The endpoint to use
+     *
      * @return Endpoint|$this
      */
     public function endpoint(Endpoint $endpoint = null)
@@ -133,19 +162,27 @@ class Query
         ));
     }
 
+    /**
+     * Alias a field with the endpoint's current alias.
+     *
+     * @param string $field The field to alias.
+     * @return string The field prefixed with the endpoint alias.
+     */
     public function aliasField($field)
     {
         return [$field => $field];
     }
 
     /**
-     * @param null $conditions
-     * @param array $types
-     * @param bool|false $overwrite
+     * Apply conditions to the query
      *
-     * @return $this|array|Query
+     * @param array|null $conditions The conditions to apply
+     * @param array|null $types Not used
+     * @param bool $overwrite Whether to overwrite the current conditions
+     *
+     * @return $this|array
      */
-    public function where($conditions = null, $types = [], $overwrite = false)
+    public function where(array $conditions = null, $types = [], $overwrite = false)
     {
         if ($conditions === null) {
             return $this->_conditions;
@@ -156,6 +193,13 @@ class Query
         return $this;
     }
 
+    /**
+     * Charge this query's action
+     *
+     * @param int|null $action Action to use
+     *
+     * @return $this|int
+     */
     public function action($action = null)
     {
         if ($action === null) {
@@ -167,10 +211,28 @@ class Query
         return $this;
     }
 
-    public function page($page = null)
+    /**
+     * Set the page of results you want.
+     *
+     * This method provides an easier to use interface to set the limit + offset
+     * in the record set you want as results. If empty the limit will default to
+     * the existing limit clause, and if that too is empty, then `25` will be used.
+     *
+     * Pages should start at 1.
+     *
+     * @param int $page The page number you want.
+     * @param int $limit The number of rows you want in the page. If null
+     *  the current limit clause will be used.
+     *
+     * @return $this
+     */
+    public function page($page = null, $limit = null)
     {
         if ($page === null) {
             return $this->_page;
+        }
+        if ($limit !== null) {
+            $this->limit($limit);
         }
 
         $this->_page = $page;
@@ -178,6 +240,22 @@ class Query
         return $this;
     }
 
+    /**
+     * Sets the number of records that should be retrieved from database,
+     * accepts an integer or an expression object that evaluates to an integer.
+     * In some databases, this operation might not be supported or will require
+     * the query to be transformed in order to limit the result set size.
+     *
+     * ### Examples
+     *
+     * ```
+     * $query->limit(10) // generates LIMIT 10
+     * ```
+     *
+     * @param int $limit number of records to be returned
+     *
+     * @return $this
+     */
     public function limit($limit = null)
     {
         if ($limit === null) {
@@ -190,7 +268,10 @@ class Query
     }
 
     /**
-     * @param null $fields
+     * Set fields to save in resources
+     *
+     * @param array|null $fields The field to set
+     *
      * @return $this|array
      */
     public function set($fields = null)
@@ -208,6 +289,13 @@ class Query
         return $this;
     }
 
+    /**
+     * Set the order in which results should be
+     *
+     * @param array|null $fields The array of fields and their direction
+     *
+     * @return $this|array
+     */
     public function order(array $fields = null)
     {
         if ($fields === null) {
@@ -224,6 +312,7 @@ class Query
      * This is handy for passing all query clauses at once.
      *
      * @param array $options the options to be applied
+     *
      * @return $this This object
      */
     public function applyOptions(array $options)
@@ -249,6 +338,11 @@ class Query
         return $this;
     }
 
+    /**
+     * Returns the total amount of results for this query
+     *
+     * @return bool|int
+     */
     public function count()
     {
         if ($this->action() !== self::ACTION_READ) {
@@ -263,7 +357,16 @@ class Query
     }
 
     /**
-     * @inheritDoc
+     * Returns the first result out of executing this query, if the query has not been
+     * executed before, it will set the limit clause to 1 for performance reasons.
+     *
+     * ### Example:
+     *
+     * ```
+     * $singleUser = $query->first();
+     * ```
+     *
+     * @return mixed the first result from the ResultSet
      */
     public function first()
     {
@@ -274,6 +377,11 @@ class Query
         return $this->all()->first();
     }
 
+    /**
+     * Execute the query
+     *
+     * @return \Traversable
+     */
     public function execute()
     {
         return $this->_execute();
@@ -291,6 +399,11 @@ class Query
         ]);
     }
 
+    /**
+     * Return a handy representation of the query
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Query.php
+++ b/src/Query.php
@@ -51,7 +51,8 @@ class Query
     private $_conditions = [];
     private $_page;
     private $_limit;
-    private $_sort = [];
+    private $_fields = [];
+    private $_order = [];
 
     /**
      * @var \Muffin\Webservice\Webservice\WebserviceInterface
@@ -168,13 +169,32 @@ class Query
         return $this;
     }
 
-    public function sort(array $fields = null)
+    /**
+     * @param null $fields
+     * @return $this|array
+     */
+    public function set($fields = null)
     {
-        if ($fields === null) {
-            return $this->_sort;
+        if (!in_array($this->action(), [self::ACTION_CREATE, self::ACTION_UPDATE])) {
+            throw new \UnexpectedValueException(__('The action of this query needs to be either create update'));
         }
 
-        $this->_sort = $fields;
+        if ($fields === null) {
+            return $this->_fields;
+        }
+
+        $this->_fields = $fields;
+
+        return $this;
+    }
+
+    public function order(array $fields = null)
+    {
+        if ($fields === null) {
+            return $this->_order;
+        }
+
+        $this->_order = $fields;
 
         return $this;
     }
@@ -199,12 +219,14 @@ class Query
             unset($options['limit']);
         }
         if (isset($options['order'])) {
-            $this->sort($options['order']);
+            $this->order($options['order']);
 
             unset($options['order']);
         }
 
         $this->_options = Hash::merge($this->_options, $options);
+
+        return $this;
     }
 
     public function count()
@@ -248,7 +270,8 @@ class Query
             'action' => $this->action(),
             'page' => $this->page(),
             'limit' => $this->limit(),
-            'sort' => $this->sort(),
+            'set' => $this->set(),
+            'sort' => $this->order(),
             'extraOptions' => $this->getOptions(),
             'conditions' => $this->conditions(),
             'repository' => $this->endpoint(),

--- a/src/Query.php
+++ b/src/Query.php
@@ -7,10 +7,11 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
 use Cake\Utility\Hash;
+use IteratorAggregate;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 
-class Query implements QueryInterface
+class Query implements QueryInterface, IteratorAggregate
 {
 
     use QueryTrait;

--- a/src/Query.php
+++ b/src/Query.php
@@ -91,7 +91,7 @@ class Query implements QueryInterface, IteratorAggregate
      */
     public function __construct(WebserviceInterface $webservice, Endpoint $endpoint)
     {
-        $this->_webservice = $webservice;
+        $this->webservice($webservice);
         $this->endpoint($endpoint);
     }
 
@@ -178,6 +178,24 @@ class Query implements QueryInterface, IteratorAggregate
         }
 
         $this->repository($endpoint);
+
+        return $this;
+    }
+
+    /**
+     * Set the webservice to be used
+     *
+     * @param null|\Muffin\Webservice\Webservice\WebserviceInterface $webservice The webservice to use
+     *
+     * @return \Muffin\Webservice\Webservice\WebserviceInterface|self
+     */
+    public function webservice(WebserviceInterface $webservice = null)
+    {
+        if ($webservice === null) {
+            return $this->_webservice;
+        }
+
+        $this->_webservice = $webservice;
 
         return $this;
     }

--- a/src/QueryLogger.php
+++ b/src/QueryLogger.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Muffin\Webservice;
+
+class QueryLogger extends \Cake\Database\Log\QueryLogger
+{
+
+}

--- a/src/QueryLogger.php
+++ b/src/QueryLogger.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Muffin\Webservice;
-
-class QueryLogger extends \Cake\Database\Log\QueryLogger
-{
-
-}

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Muffin\Webservice;
+
+use Cake\Collection\CollectionTrait;
+use Cake\Datasource\ResultSetInterface;
+
+class ResultSet implements ResultSetInterface
+{
+
+    use CollectionTrait;
+
+    /**
+     * Points to the next record number that should be fetched
+     *
+     * @var int
+     */
+    protected $_index = 0;
+
+    /**
+     * Last record fetched from the statement
+     *
+     * @var array
+     */
+    protected $_current;
+
+    /**
+     * Results that have been fetched or hydrated into the results.
+     *
+     * @var array
+     */
+    protected $_results = [];
+
+    protected $_total;
+
+    public function __construct(array $resources, $total = null)
+    {
+        $this->_results = \SplFixedArray::fromArray($resources, false);
+        $this->_total = $total;
+    }
+
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Return the current element
+     * @link http://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     */
+    public function current()
+    {
+        return $this->_current;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Rewind the Iterator to the first element
+     * @link http://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     */
+    public function rewind()
+    {
+        $this->_index = 0;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * String representation of object
+     * @link http://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     */
+    public function serialize()
+    {
+        while ($this->valid()) {
+            $this->next();
+        }
+        return serialize($this->_results);
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Checks if current position is valid
+     * @link http://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     */
+    public function valid()
+    {
+        if (!isset($this->_results[$this->key()])) {
+            return false;
+        }
+
+        $this->_current = $this->_results[$this->key()];
+
+        return true;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Return the key of the current element
+     * @link http://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     */
+    public function key()
+    {
+        return $this->_index;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Move forward to next element
+     * @link http://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     */
+    public function next()
+    {
+        $this->_index++;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Constructs the object
+     * @link http://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $this->_results = unserialize($serialized);
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.1.0)<br/>
+     * Count elements of an object
+     * @link http://php.net/manual/en/countable.count.php
+     * @return int The custom count as an integer.
+     * </p>
+     * <p>
+     * The return value is cast to an integer.
+     */
+    public function count()
+    {
+        return count($this->_results);
+    }
+
+    public function total()
+    {
+        return $this->_total;
+    }
+}

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -33,18 +33,20 @@ class ResultSet implements ResultSetInterface
 
     protected $_total;
 
+    /**
+     * Construct the ResultSet
+     *
+     * @param array $resources The resources to attach
+     * @param int|null $total The total amount of resources available
+     */
     public function __construct(array $resources, $total = null)
     {
         $this->_results = \SplFixedArray::fromArray($resources, false);
         $this->_total = $total;
     }
 
-
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Return the current element
-     * @link http://php.net/manual/en/iterator.current.php
-     * @return mixed Can return any type.
+     * {@inheritDoc}
      */
     public function current()
     {
@@ -52,10 +54,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Rewind the Iterator to the first element
-     * @link http://php.net/manual/en/iterator.rewind.php
-     * @return void Any returned value is ignored.
+     * {@inheritDoc}
      */
     public function rewind()
     {
@@ -63,10 +62,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * String representation of object
-     * @link http://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
+     * {@inheritDoc}
      */
     public function serialize()
     {
@@ -77,11 +73,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Checks if current position is valid
-     * @link http://php.net/manual/en/iterator.valid.php
-     * @return boolean The return value will be casted to boolean and then evaluated.
-     * Returns true on success or false on failure.
+     * {@inheritDoc}
      */
     public function valid()
     {
@@ -95,10 +87,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Return the key of the current element
-     * @link http://php.net/manual/en/iterator.key.php
-     * @return mixed scalar on success, or null on failure.
+     * {@inheritDoc}
      */
     public function key()
     {
@@ -106,10 +95,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Move forward to next element
-     * @link http://php.net/manual/en/iterator.next.php
-     * @return void Any returned value is ignored.
+     * {@inheritDoc}
      */
     public function next()
     {
@@ -117,13 +103,7 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * Constructs the object
-     * @link http://php.net/manual/en/serializable.unserialize.php
-     * @param string $serialized <p>
-     * The string representation of the object.
-     * </p>
-     * @return void
+     * {@inheritDoc}
      */
     public function unserialize($serialized)
     {
@@ -131,19 +111,18 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * Count elements of an object
-     * @link http://php.net/manual/en/countable.count.php
-     * @return int The custom count as an integer.
-     * </p>
-     * <p>
-     * The return value is cast to an integer.
+     * {@inheritDoc}
      */
     public function count()
     {
         return count($this->_results);
     }
 
+    /**
+     * Returns the total amount of results
+     *
+     * @return int|null
+     */
     public function total()
     {
         return $this->_total;

--- a/src/Routing/Filter/ControllerEndpointFilter.php
+++ b/src/Routing/Filter/ControllerEndpointFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Muffin\Webservice\Routing\Filter;
+
+use Cake\Event\Event;
+use Cake\Routing\DispatcherFilter;
+
+/**
+ * This filter registers the endpoint model type in controllers
+ *
+ * @package Muffin\Webservice\Routing\Filter
+ */
+class ControllerEndpointFilter extends DispatcherFilter
+{
+
+    /**
+     * Priority to use
+     *
+     * @var int
+     */
+    protected $_priority = 51;
+
+    /**
+     * @inheritDoc
+     *
+     * @param \Cake\Event\Event $event The event to handle
+     *
+     * @return void
+     */
+    public function beforeDispatch(Event $event)
+    {
+        $controller = false;
+        if (isset($event->data['controller'])) {
+            $controller = $event->data['controller'];
+        }
+        if ($controller) {
+            $callback = ['Muffin\Webservice\Model\EndpointRegistry', 'get'];
+            $controller->modelFactory('Endpoint', $callback);
+        }
+    }
+}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Muffin\Webservice;
+
+use Cake\Database\Schema\Table;
+
+class Schema extends Table
+{
+
+}

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -10,11 +10,33 @@ use Muffin\Webservice\Query;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Basic implementation of a webservice
+ *
+ * @package Muffin\Webservice\Webservice
+ */
 abstract class Webservice implements WebserviceInterface
 {
 
+    /**
+     * The driver to use to communicate with the webservice
+     *
+     * @var \Muffin\Webservice\AbstractDriver
+     */
     protected $_driver;
+
+    /**
+     * The webservice to call
+     *
+     * @var string
+     */
     protected $_endpoint;
+
+    /**
+     * A list of nested resources with their path and needed conditions
+     *
+     * @var array
+     */
     protected $_nestedResources = [];
 
     /**
@@ -46,9 +68,9 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Set the driver to use
      *
-     * @param AbstractDriver|null $driver The driver to use
+     * @param \Muffin\Webservice\AbstractDriver|null $driver The driver to use
      *
-     * @return AbstractDriver|$this
+     * @return \Muffin\Webservice\AbstractDriver|$this
      */
     public function driver(AbstractDriver $driver = null)
     {
@@ -132,7 +154,7 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Execute the appropriate method for a query
      *
-     * @param Query $query The query to execute
+     * @param \Muffin\Webservice\Query $query The query to execute
      * @param array $options The options to use
      *
      * @return bool|int|\Muffin\Webservice\ResultSet
@@ -156,7 +178,7 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Executes a query with the create action
      *
-     * @param Query $query The query to execute
+     * @param \Muffin\Webservice\Query $query The query to execute
      * @param array $options The options to use
      *
      * @return bool|void
@@ -172,7 +194,7 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Executes a query with the read action
      *
-     * @param Query $query The query to execute
+     * @param \Muffin\Webservice\Query $query The query to execute
      * @param array $options The options to use
      *
      * @return \Muffin\Webservice\ResultSet|bool|void
@@ -188,7 +210,7 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Executes a query with the update action
      *
-     * @param Query $query The query to execute
+     * @param \Muffin\Webservice\Query $query The query to execute
      * @param array $options The options to use
      *
      * @return int|bool|void
@@ -204,7 +226,7 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Executes a query with the delete action
      *
-     * @param Query $query The query to execute
+     * @param \Muffin\Webservice\Query $query The query to execute
      * @param array $options The options to use
      *
      * @return int|bool|void
@@ -236,8 +258,8 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Logs a query to the specified logger
      *
-     * @param Query $query The query to log
-     * @param LoggerInterface $logger The logger instance to use
+     * @param \Muffin\Webservice\Query $query The query to log
+     * @param \Psr\Log\LoggerInterface $logger The logger instance to use
      *
      * @return void
      */

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -143,6 +143,10 @@ abstract class Webservice implements WebserviceInterface
     {
         $result = $this->_executeQuery($query, $options);
 
+        if ($this->driver() === null) {
+            throw new \UnexpectedValueException(__('No driver has been defined'));
+        }
+
         // Write to the logger when one has been defined
         if ($this->driver()->logger()) {
             $this->_logQuery($query, $this->driver()->logger());

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -6,7 +6,7 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Utility\Text;
 use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Exception\UnimplementedWebserviceMethodException;
-use Muffin\Webservice\WebserviceQuery;
+use Muffin\Webservice\Query;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
@@ -84,7 +84,7 @@ abstract class Webservice implements WebserviceInterface
         return false;
     }
 
-    public function execute(WebserviceQuery $query, array $options = [])
+    public function execute(Query $query, array $options = [])
     {
         $result = $this->_executeQuery($query, $options);
 
@@ -95,21 +95,21 @@ abstract class Webservice implements WebserviceInterface
         return $result;
     }
 
-    protected function _executeQuery(WebserviceQuery $query, array $options = [])
+    protected function _executeQuery(Query $query, array $options = [])
     {
         switch ($query->action()) {
-            case WebserviceQuery::ACTION_CREATE:
+            case Query::ACTION_CREATE:
                 return $this->_executeCreateQuery($query, $options);
-            case WebserviceQuery::ACTION_READ:
+            case Query::ACTION_READ:
                 return $this->_executeReadQuery($query, $options);
-            case WebserviceQuery::ACTION_UPDATE:
+            case Query::ACTION_UPDATE:
                 return $this->_executeUpdateQuery($query, $options);
-            case WebserviceQuery::ACTION_DELETE:
+            case Query::ACTION_DELETE:
                 return $this->_executeDeleteQuery($query, $options);
         }
     }
 
-    protected function _executeCreateQuery(WebserviceQuery $query, array $options = [])
+    protected function _executeCreateQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
             'name' => get_class($this),
@@ -117,7 +117,7 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
-    protected function _executeReadQuery(WebserviceQuery $query, array $options = [])
+    protected function _executeReadQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
             'name' => get_class($this),
@@ -125,7 +125,7 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
-    protected function _executeUpdateQuery(WebserviceQuery $query, array $options = [])
+    protected function _executeUpdateQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
             'name' => get_class($this),
@@ -133,7 +133,7 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
-    protected function _executeDeleteQuery(WebserviceQuery $query, array $options = [])
+    protected function _executeDeleteQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
             'name' => get_class($this),
@@ -154,7 +154,7 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
-    protected function _logQuery(WebserviceQuery $query, LoggerInterface $logger)
+    protected function _logQuery(Query $query, LoggerInterface $logger)
     {
         if (!$this->driver()->logQueries()) {
             return;

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Muffin\Webservice\Webservice;
+
+use Cake\Datasource\ConnectionInterface;
+use Cake\Utility\Text;
+use Muffin\Webservice\AbstractDriver;
+use Muffin\Webservice\Exception\UnimplementedWebserviceMethodException;
+use Muffin\Webservice\WebserviceQuery;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+abstract class Webservice implements WebserviceInterface
+{
+
+    protected $_driver;
+    protected $_endpoint;
+    protected $_nestedResources = [];
+
+    public function __construct(array $config = [])
+    {
+        if (!empty($config['driver'])) {
+            $this->driver($config['driver']);
+        }
+        if (!empty($config['endpoint'])) {
+            $this->endpoint($config['endpoint']);
+        }
+
+        $this->initialize();
+    }
+
+    public function initialize()
+    {
+
+    }
+
+    /**
+     * @param AbstractDriver|null $driver
+     * @return AbstractDriver|$this
+     */
+    public function driver(AbstractDriver $driver = null)
+    {
+        if ($driver === null) {
+            return $this->_driver;
+        }
+
+        $this->_driver = $driver;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $endpoint
+     * @return string|$this
+     */
+    public function endpoint($endpoint = null)
+    {
+        if ($endpoint === null) {
+            return $this->_endpoint;
+        }
+
+        $this->_endpoint = $endpoint;
+
+        return $this;
+    }
+
+    public function addNestedResource($url, array $requiredFields)
+    {
+        $this->_nestedResources[$url] = [
+            'requiredFields' => $requiredFields
+        ];
+    }
+
+    public function nestedResource(array $conditions)
+    {
+        foreach ($this->_nestedResources as $url => $options) {
+            if (count(array_intersect_key(array_flip($options['requiredFields']), $conditions)) !== count($options['requiredFields'])) {
+                continue;
+            }
+
+            return Text::insert($url, $conditions);
+        }
+
+        return false;
+    }
+
+    public function execute(WebserviceQuery $query, array $options = [])
+    {
+        $result = $this->_executeQuery($query, $options);
+
+        if ($this->driver()->logger()) {
+            $this->_logQuery($query, $this->driver()->logger());
+        }
+
+        return $result;
+    }
+
+    protected function _executeQuery(WebserviceQuery $query, array $options = [])
+    {
+        switch ($query->action()) {
+            case WebserviceQuery::ACTION_CREATE:
+                return $this->_executeCreateQuery($query, $options);
+            case WebserviceQuery::ACTION_READ:
+                return $this->_executeReadQuery($query, $options);
+            case WebserviceQuery::ACTION_UPDATE:
+                return $this->_executeUpdateQuery($query, $options);
+            case WebserviceQuery::ACTION_DELETE:
+                return $this->_executeDeleteQuery($query, $options);
+        }
+    }
+
+    protected function _executeCreateQuery(WebserviceQuery $query, array $options = [])
+    {
+        throw new UnimplementedWebserviceMethodException([
+            'name' => get_class($this),
+            'method' => '_executeCreateQuery'
+        ]);
+    }
+
+    protected function _executeReadQuery(WebserviceQuery $query, array $options = [])
+    {
+        throw new UnimplementedWebserviceMethodException([
+            'name' => get_class($this),
+            'method' => '_executeReadQuery'
+        ]);
+    }
+
+    protected function _executeUpdateQuery(WebserviceQuery $query, array $options = [])
+    {
+        throw new UnimplementedWebserviceMethodException([
+            'name' => get_class($this),
+            'method' => '_executeUpdateQuery'
+        ]);
+    }
+
+    protected function _executeDeleteQuery(WebserviceQuery $query, array $options = [])
+    {
+        throw new UnimplementedWebserviceMethodException([
+            'name' => get_class($this),
+            'method' => '_executeDeleteQuery'
+        ]);
+    }
+
+    /**
+     * @param string $resourceClass
+     * @param array $properties
+     * @return \Muffin\Webservice\Model\Resource
+     */
+    protected function _createResource($resourceClass, array $properties = [])
+    {
+        return new $resourceClass($properties, [
+            'markClean' => true,
+            'markNew' => false,
+        ]);
+    }
+
+    protected function _logQuery(WebserviceQuery $query, LoggerInterface $logger)
+    {
+        if (!$this->driver()->logQueries()) {
+            return;
+        }
+
+        $logger->debug($query->endpoint(), [
+            'params' => $query->conditions()
+        ]);
+    }
+
+    /**
+     * Loops through the results and turns them into resource objects
+     *
+     * @param array $results Array of results from the API
+     * @param string $resourceClass The resource class to use
+     *
+     * @return array Array of resource objects
+     */
+    protected function _transformResults(array $results, $resourceClass)
+    {
+        $resources = [];
+        foreach ($results as $result) {
+            $resources[] = $this->_transformResource($result, $resourceClass);
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Turns a single result into a resource
+     *
+     * @param array $result
+     * @param string $resourceClass
+     * @return \Muffin\Webservice\Model\Resource
+     */
+    protected function _transformResource(array $result, $resourceClass)
+    {
+        $properties = [];
+
+        foreach ($result as $property => $value) {
+            $properties[$property] = $value;
+        }
+
+        return $this->_createResource($resourceClass, $properties);
+    }
+
+    public function __debugInfo()
+    {
+        return [
+            'driver' => $this->driver(),
+            'endpoint' => $this->endpoint(),
+        ];
+    }
+}

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -17,6 +17,11 @@ abstract class Webservice implements WebserviceInterface
     protected $_endpoint;
     protected $_nestedResources = [];
 
+    /**
+     * Construct the webservice
+     *
+     * @param array $config The config to use
+     */
     public function __construct(array $config = [])
     {
         if (!empty($config['driver'])) {
@@ -29,13 +34,20 @@ abstract class Webservice implements WebserviceInterface
         $this->initialize();
     }
 
+    /**
+     * Initialize the webservice
+     *
+     * @return void
+     */
     public function initialize()
     {
-
     }
 
     /**
-     * @param AbstractDriver|null $driver
+     * Set the driver to use
+     *
+     * @param AbstractDriver|null $driver The driver to use
+     *
      * @return AbstractDriver|$this
      */
     public function driver(AbstractDriver $driver = null)
@@ -50,7 +62,10 @@ abstract class Webservice implements WebserviceInterface
     }
 
     /**
-     * @param string|null $endpoint
+     * Set the endpoint path to use
+     *
+     * @param string|null $endpoint The endpoint
+     *
      * @return string|$this
      */
     public function endpoint($endpoint = null)
@@ -64,6 +79,14 @@ abstract class Webservice implements WebserviceInterface
         return $this;
     }
 
+    /**
+     * Add a nested resource
+     *
+     * @param string $url The URL to use as base
+     * @param array $requiredFields The required fields
+     *
+     * @return void
+     */
     public function addNestedResource($url, array $requiredFields)
     {
         $this->_nestedResources[$url] = [
@@ -71,6 +94,13 @@ abstract class Webservice implements WebserviceInterface
         ];
     }
 
+    /**
+     * Checks if a set of conditions match a nested resource
+     *
+     * @param array $conditions The conditions in a query
+     *
+     * @return bool|string Either a URL or false in case no nested resource matched
+     */
     public function nestedResource(array $conditions)
     {
         foreach ($this->_nestedResources as $url => $options) {
@@ -84,10 +114,14 @@ abstract class Webservice implements WebserviceInterface
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function execute(Query $query, array $options = [])
     {
         $result = $this->_executeQuery($query, $options);
 
+        // Write to the logger when one has been defined
         if ($this->driver()->logger()) {
             $this->_logQuery($query, $this->driver()->logger());
         }
@@ -95,6 +129,14 @@ abstract class Webservice implements WebserviceInterface
         return $result;
     }
 
+    /**
+     * Execute the appropriate method for a query
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return bool|int|\Muffin\Webservice\ResultSet
+     */
     protected function _executeQuery(Query $query, array $options = [])
     {
         switch ($query->action()) {
@@ -107,8 +149,18 @@ abstract class Webservice implements WebserviceInterface
             case Query::ACTION_DELETE:
                 return $this->_executeDeleteQuery($query, $options);
         }
+
+        return false;
     }
 
+    /**
+     * Executes a query with the create action
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return bool|void
+     */
     protected function _executeCreateQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
@@ -117,6 +169,14 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
+    /**
+     * Executes a query with the read action
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return \Muffin\Webservice\ResultSet|bool|void
+     */
     protected function _executeReadQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
@@ -125,6 +185,14 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
+    /**
+     * Executes a query with the update action
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return int|bool|void
+     */
     protected function _executeUpdateQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
@@ -133,6 +201,14 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
+    /**
+     * Executes a query with the delete action
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return int|bool|void
+     */
     protected function _executeDeleteQuery(Query $query, array $options = [])
     {
         throw new UnimplementedWebserviceMethodException([
@@ -142,8 +218,11 @@ abstract class Webservice implements WebserviceInterface
     }
 
     /**
-     * @param string $resourceClass
-     * @param array $properties
+     * Creates a resource with the given class and properties
+     *
+     * @param string $resourceClass The class to use to create the resource
+     * @param array $properties The properties to apply
+     *
      * @return \Muffin\Webservice\Model\Resource
      */
     protected function _createResource($resourceClass, array $properties = [])
@@ -154,6 +233,14 @@ abstract class Webservice implements WebserviceInterface
         ]);
     }
 
+    /**
+     * Logs a query to the specified logger
+     *
+     * @param Query $query The query to log
+     * @param LoggerInterface $logger The logger instance to use
+     *
+     * @return void
+     */
     protected function _logQuery(Query $query, LoggerInterface $logger)
     {
         if (!$this->driver()->logQueries()) {
@@ -161,7 +248,7 @@ abstract class Webservice implements WebserviceInterface
         }
 
         $logger->debug($query->endpoint(), [
-            'params' => $query->conditions()
+            'params' => $query->where()
         ]);
     }
 
@@ -186,8 +273,8 @@ abstract class Webservice implements WebserviceInterface
     /**
      * Turns a single result into a resource
      *
-     * @param array $result
-     * @param string $resourceClass
+     * @param array $result The API result
+     * @param string $resourceClass The resource class to use
      * @return \Muffin\Webservice\Model\Resource
      */
     protected function _transformResource(array $result, $resourceClass)
@@ -201,6 +288,11 @@ abstract class Webservice implements WebserviceInterface
         return $this->_createResource($resourceClass, $properties);
     }
 
+    /**
+     * Creates a handy representation of the webservice
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -284,7 +284,7 @@ abstract class Webservice implements WebserviceInterface
      * @param array $results Array of results from the API
      * @param string $resourceClass The resource class to use
      *
-     * @return array Array of resource objects
+     * @return Resource[] Array of resource objects
      */
     protected function _transformResults(array $results, $resourceClass)
     {
@@ -301,6 +301,7 @@ abstract class Webservice implements WebserviceInterface
      *
      * @param array $result The API result
      * @param string $resourceClass The resource class to use
+     *
      * @return \Muffin\Webservice\Model\Resource
      */
     protected function _transformResource(array $result, $resourceClass)

--- a/src/Webservice/WebserviceInterface.php
+++ b/src/Webservice/WebserviceInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Muffin\Webservice\Webservice;
+
+use Muffin\Webservice\WebserviceQuery;
+
+interface WebserviceInterface
+{
+
+    public function execute(WebserviceQuery $query);
+}

--- a/src/Webservice/WebserviceInterface.php
+++ b/src/Webservice/WebserviceInterface.php
@@ -4,6 +4,11 @@ namespace Muffin\Webservice\Webservice;
 
 use Muffin\Webservice\Query;
 
+/**
+ * Describes a webservice used to call a API
+ *
+ * @package Muffin\Webservice\Webservice
+ */
 interface WebserviceInterface
 {
 

--- a/src/Webservice/WebserviceInterface.php
+++ b/src/Webservice/WebserviceInterface.php
@@ -2,10 +2,10 @@
 
 namespace Muffin\Webservice\Webservice;
 
-use Muffin\Webservice\WebserviceQuery;
+use Muffin\Webservice\Query;
 
 interface WebserviceInterface
 {
 
-    public function execute(WebserviceQuery $query);
+    public function execute(Query $query);
 }

--- a/src/Webservice/WebserviceInterface.php
+++ b/src/Webservice/WebserviceInterface.php
@@ -7,5 +7,13 @@ use Muffin\Webservice\Query;
 interface WebserviceInterface
 {
 
-    public function execute(Query $query);
+    /**
+     * Executes a query
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return \Muffin\Webservice\ResultSet|int|bool
+     */
+    public function execute(Query $query, array $options = []);
 }

--- a/src/WebserviceQuery.php
+++ b/src/WebserviceQuery.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Muffin\Webservice;
+
+use Cake\Datasource\QueryTrait;
+use Cake\Datasource\RepositoryInterface;
+use Cake\Error\Debugger;
+use Cake\Utility\Hash;
+use Muffin\Webservice\Model\Endpoint;
+use Muffin\Webservice\Webservice\WebserviceInterface;
+
+class WebserviceQuery
+{
+
+    use QueryTrait;
+
+    const ACTION_CREATE = 1;
+    const ACTION_READ = 2;
+    const ACTION_UPDATE = 3;
+    const ACTION_DELETE = 4;
+
+    /**
+     * Indicates that the operation should append to the list
+     *
+     * @var int
+     */
+    const APPEND = 0;
+
+    /**
+     * Indicates that the operation should prepend to the list
+     *
+     * @var int
+     */
+    const PREPEND = 1;
+
+    /**
+     * Indicates that the operation should overwrite the list
+     *
+     * @var bool
+     */
+    const OVERWRITE = true;
+
+    /**
+     * Indicates whether internal state of this query was changed, this is used to
+     * discard internal cached objects such as the transformed query or the reference
+     * to the executed statement.
+     *
+     * @var bool
+     */
+    protected $_dirty = false;
+
+    private $_action;
+    private $_conditions = [];
+    private $_page;
+    private $_limit;
+    private $_sort = [];
+
+    /**
+     * @var \Muffin\Webservice\Webservice\WebserviceInterface
+     */
+    protected $_webservice;
+
+    /**
+     * @var ResultSet
+     */
+    protected $_resultSet;
+
+    public function __construct(WebserviceInterface $webservice, Endpoint $endpoint)
+    {
+        $this->_webservice = $webservice;
+        $this->endpoint($endpoint);
+    }
+
+    public function create()
+    {
+        $this->action(self::ACTION_CREATE);
+
+        return $this;
+    }
+
+    public function read()
+    {
+        $this->action(self::ACTION_READ);
+
+        return $this;
+    }
+
+    public function update()
+    {
+        $this->action(self::ACTION_UPDATE);
+
+        return $this;
+    }
+
+    public function delete()
+    {
+        $this->action(self::ACTION_DELETE);
+
+        return $this;
+    }
+
+    /**
+     * @param Endpoint|null $endpoint
+     * @return Endpoint|$this
+     */
+    public function endpoint(Endpoint $endpoint = null)
+    {
+        if ($endpoint === null) {
+            return $this->repository();
+        }
+
+        $this->repository($endpoint);
+
+        return $this;
+    }
+
+    public function aliasField($field)
+    {
+        return [$field => $field];
+    }
+
+    /**
+     * @param null $conditions
+     * @param array $types
+     * @param bool|false $overwrite
+     *
+     * @internal This method is only for compatibility with some plugins
+     *
+     * @return $this|array|WebserviceQuery
+     */
+    public function where($conditions = null, $types = [], $overwrite = false)
+    {
+        return $this->conditions($conditions, !$overwrite);
+    }
+
+    public function action($action = null)
+    {
+        if ($action === null) {
+            return $this->_action;
+        }
+
+        $this->_action = $action;
+
+        return $this;
+    }
+
+    public function conditions(array $conditions = null, $merge = true)
+    {
+        if ($conditions === null) {
+            return $this->_conditions;
+        }
+
+        $this->_conditions = ($merge) ? Hash::merge($this->_conditions, $conditions) : $conditions;
+
+        return $this;
+    }
+
+    public function page($page = null)
+    {
+        if ($page === null) {
+            return $this->_page;
+        }
+
+        $this->_page = $page;
+
+        return $this;
+    }
+
+    public function limit($limit = null)
+    {
+        if ($limit === null) {
+            return $this->_limit;
+        }
+
+        $this->_limit = $limit;
+
+        return $this;
+    }
+
+    public function sort(array $fields = null)
+    {
+        if ($fields === null) {
+            return $this->_sort;
+        }
+
+        $this->_sort = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Populates or adds parts to current query clauses using an array.
+     * This is handy for passing all query clauses at once.
+     *
+     * @param array $options the options to be applied
+     * @return $this This object
+     */
+    public function applyOptions(array $options)
+    {
+        if (isset($options['page'])) {
+            $this->page($options['page']);
+
+            unset($options['page']);
+        }
+        if (isset($options['limit'])) {
+            $this->limit($options['limit']);
+
+            unset($options['limit']);
+        }
+        if (isset($options['order'])) {
+            $this->sort($options['order']);
+
+            unset($options['order']);
+        }
+
+        $this->_options = Hash::merge($this->_options, $options);
+    }
+
+    public function count()
+    {
+        if (!$this->_resultSet) {
+            $this->_execute();
+        }
+
+        return $this->_resultSet->total();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function first()
+    {
+        if (!$this->_resultSet) {
+            $this->limit(1);
+        }
+
+        return $this->all()->first();
+    }
+
+
+    /**
+     * Executes this query and returns a traversable object containing the results
+     *
+     * @return \Traversable
+     */
+    protected function _execute()
+    {
+        return $this->_resultSet = $this->_webservice->execute($this, [
+            'resourceClass' => $this->endpoint()->resourceClass()
+        ]);
+    }
+
+    public function __debugInfo()
+    {
+        return [
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
+            'action' => $this->action(),
+            'page' => $this->page(),
+            'limit' => $this->limit(),
+            'sort' => $this->sort(),
+            'extraOptions' => $this->getOptions(),
+            'conditions' => $this->conditions(),
+            'repository' => $this->endpoint(),
+            'webservice' => $this->_webservice
+        ];
+    }
+}

--- a/tests/TestCase/ConnectionTest.php
+++ b/tests/TestCase/ConnectionTest.php
@@ -2,11 +2,44 @@
 namespace Muffin\Webservice\Test\TestCase;
 
 use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Connection;
 
 class ConnectionTest extends TestCase
 {
-    public function testConstructor()
+
+    /**
+     * @var Connection
+     */
+    public $connection;
+
+    public function setUp()
     {
-        $this->markTestIncomplete('Not yet implemented.');
+        parent::setUp();
+
+        $this->connection = new Connection([
+            'name' => 'test',
+            'service' => 'Test'
+        ]);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\MissingDriverException
+     */
+    public function testConstructorMissingDriver()
+    {
+        new Connection([
+            'name' => 'test',
+            'service' => 'MissingDriver'
+        ]);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\MissingConnectionException
+     */
+    public function testConstructorNoDriver()
+    {
+        new Connection([
+            'name' => 'test',
+        ]);
     }
 }

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -1,7 +1,26 @@
 <?php
 
+namespace App\Model\Endpoint;
+
+use Muffin\Webservice\Model\Endpoint;
+
+class AppEndpoint extends Endpoint
+{
+
+}
+
+namespace SomeVendor\SomePlugin\Model\Endpoint;
+
+use Muffin\Webservice\Model\Endpoint;
+
+class PluginEndpoint extends Endpoint
+{
+
+}
+
 namespace Muffin\Webservice\Test\TestCase\Model;
 
+use App\Model\Endpoint\AppEndpoint;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\TestSuite\TestCase;
 use Muffin\Webservice\AbstractDriver;
@@ -11,6 +30,7 @@ use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\ResultSet;
 use Muffin\Webservice\Webservice\Webservice;
+use SomeVendor\SomePlugin\Model\Endpoint\PluginEndpoint;
 
 class TestDriver extends AbstractDriver
 {
@@ -284,5 +304,11 @@ class EndpointTest extends TestCase
         $this->assertEquals(3, $amount);
 
         $this->assertEquals(0, $this->endpoint->find()->count());
+    }
+
+    public function testDefaultConnectionName()
+    {
+        $this->assertEquals('app', AppEndpoint::defaultConnectionName());
+        $this->assertEquals('some_plugin', PluginEndpoint::defaultConnectionName());
     }
 }

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -121,6 +121,19 @@ class EndpointTestWebservice extends Webservice
                 $this->resources[$index]
             ], 1);
         }
+        if (isset($query->where()[$query->endpoint()->aliasField('title')])) {
+            $resources = [];
+
+            foreach ($this->resources as $resource) {
+                if ($resource->title !== $query->where()[$query->endpoint()->aliasField('title')]) {
+                    continue;
+                }
+
+                $resources[] = $resource;
+            }
+
+            return new ResultSet($resources, count($resources));
+        }
 
         return new ResultSet($this->resources, count($this->resources));
     }
@@ -222,6 +235,18 @@ class EndpointTest extends TestCase
         $query = $this->endpoint->find();
 
         $this->assertInstanceOf('\Muffin\Webservice\Query', $query);
+    }
+
+    public function testFindByTitle()
+    {
+        $this->assertEquals(new Resource([
+            'id' => 3,
+            'title' => 'Webservices',
+            'body' => 'Even more text'
+        ], [
+            'markNew' => false,
+            'markClean' => true
+        ]), $this->endpoint->findByTitle('Webservices')->first());
     }
 
     public function testFindList()

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -23,6 +23,7 @@ namespace Muffin\Webservice\Test\TestCase\Model;
 use App\Model\Endpoint\AppEndpoint;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
 use Muffin\Webservice\AbstractDriver;
 use Muffin\Webservice\Connection;
 use Muffin\Webservice\Model\Endpoint;
@@ -167,6 +168,30 @@ class EndpointTestWebservice extends Webservice
     }
 }
 
+class TestEndpoint extends Endpoint
+{
+
+
+    /**
+     * Returns the default validator object. Subclasses can override this function
+     * to add a default validation set to the validator object.
+     *
+     * @param \Cake\Validation\Validator $validator The validator that can be modified to
+     * add some rules to it.
+     *
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator->requirePresence('title')
+            ->notEmpty('title')
+            ->requirePresence('body')
+            ->notEmpty('body');
+
+        return $validator;
+    }
+}
+
 class EndpointTest extends TestCase
 {
 
@@ -182,7 +207,7 @@ class EndpointTest extends TestCase
     {
         parent::setUp();
 
-        $this->endpoint = new Endpoint([
+        $this->endpoint = new TestEndpoint([
             'connection' => new Connection([
                 'name' => 'test',
                 'driver' => '\Muffin\Webservice\Test\TestCase\Model\TestDriver'
@@ -304,6 +329,40 @@ class EndpointTest extends TestCase
         $this->assertEquals(3, $amount);
 
         $this->assertEquals(0, $this->endpoint->find()->count());
+    }
+
+    public function testNewEntity()
+    {
+        $this->assertEquals(new Resource([
+            'title' => 'New entity',
+            'body' => 'New entity body'
+        ]), $this->endpoint->newEntity([
+           'title' => 'New entity',
+            'body' => 'New entity body'
+        ]));
+    }
+
+    public function testNewEntities()
+    {
+        $this->assertEquals([
+            new Resource([
+                'title' => 'New entity',
+                'body' => 'New entity body'
+            ]),
+            new Resource([
+                'title' => 'Second new entity',
+                'body' => 'Second new entity body'
+            ])
+        ], $this->endpoint->newEntities([
+            [
+                'title' => 'New entity',
+                'body' => 'New entity body'
+            ],
+            [
+                'title' => 'Second new entity',
+                'body' => 'Second new entity body'
+            ]
+        ]));
     }
 
     public function testDefaultConnectionName()

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase\Model;
+
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\AbstractDriver;
+use Muffin\Webservice\Connection;
+use Muffin\Webservice\Model\Endpoint;
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\Query;
+use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Webservice\Webservice;
+
+class TestDriver extends AbstractDriver
+{
+
+    /**
+     * Initialize is used to easily extend the constructor.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        // TODO: Implement initialize() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _createWebservice($className, array $options = [])
+    {
+        return new EndpointTestWebservice($options);
+    }
+}
+
+class EndpointTestWebservice extends Webservice
+{
+
+    public $resources;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->resources = [
+            new Resource([
+                'id' => 1,
+                'title' => 'Hello World',
+                'body' => 'Some text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ]),
+            new Resource([
+                'id' => 2,
+                'title' => 'New ORM',
+                'body' => 'Some more text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ]),
+            new Resource([
+                'id' => 3,
+                'title' => 'Webservices',
+                'body' => 'Even more text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ])
+        ];
+    }
+
+
+    protected function _executeCreateQuery(Query $query, array $options = [])
+    {
+        $fields = $query->set();
+
+        if (!is_numeric($fields['id'])) {
+            return false;
+        }
+
+        $this->resources[] = new Resource($fields, [
+            'markNew' => false,
+            'markClean' => true
+        ]);
+
+        return true;
+    }
+
+    protected function _executeReadQuery(Query $query, array $options = [])
+    {
+        if (!empty($query->where()['id'])) {
+            $index = $this->conditionsToIndex($query->where());
+
+            if (!isset($this->resources[$index])) {
+                return new ResultSet([], 0);
+            }
+
+            return new ResultSet([
+                $this->resources[$index]
+            ], 1);
+        }
+
+        return new ResultSet($this->resources, 6);
+    }
+
+    protected function _executeUpdateQuery(Query $query, array $options = [])
+    {
+        $this->resources[$this->conditionsToIndex($query->where())]->set($query->set());
+
+        $this->resources[$this->conditionsToIndex($query->where())]->clean();
+
+        return 1;
+    }
+
+    protected function _executeDeleteQuery(Query $query, array $options = [])
+    {
+        unset($this->resources[$this->conditionsToIndex($query->where())]);
+
+        return true;
+    }
+
+    public function conditionsToIndex(array $conditions)
+    {
+        return $conditions['id'] - 1;
+    }
+}
+
+class EndpointTest extends TestCase
+{
+
+    /**
+     * @var Endpoint
+     */
+    public $endpoint;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->endpoint = new Endpoint([
+            'connection' => new Connection([
+                'name' => 'test',
+                'driver' => '\Muffin\Webservice\Test\TestCase\Model\TestDriver'
+            ]),
+            'primaryKey' => 'id',
+            'displayField' => 'title'
+        ]);
+    }
+
+    public function testFind()
+    {
+        $query = $this->endpoint->find();
+
+        $this->assertInstanceOf('\Muffin\Webservice\Query', $query);
+    }
+
+    public function testFindList()
+    {
+        $this->assertEquals([
+            1 => 'Hello World',
+            2 => 'New ORM',
+            3 => 'Webservices'
+        ], $this->endpoint->find('list')->toArray());
+
+        $this->assertEquals([
+            'Hello World' => 'Some text',
+            'New ORM' => 'Some more text',
+            'Webservices' => 'Even more text'
+        ], $this->endpoint->find('list', [
+            'keyField' => 'title',
+            'valueField' => 'body'
+        ])->toArray());
+    }
+
+    public function testGet()
+    {
+        $resource = $this->endpoint->get(2);
+
+        $this->assertEquals('New ORM', $resource->title);
+    }
+
+    public function testExists()
+    {
+        $this->assertTrue($this->endpoint->exists(['id' => 1]));
+
+        $this->assertFalse($this->endpoint->exists(['id' => 10]));
+    }
+
+    /**
+     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
+     */
+    public function testGetNonExisting()
+    {
+        $this->endpoint->get(10);
+    }
+
+    public function testSave()
+    {
+        $resource = new Resource([
+            'id' => 4,
+            'title' => 'Loads of fun',
+            'body' => 'Woot'
+        ]);
+
+        $savedResource = $this->endpoint->save($resource);
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $savedResource);
+        $this->assertFalse($savedResource->isNew());
+
+        $newResource = $this->endpoint->get(4);
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $newResource);
+        $this->assertEquals([
+            'id' => 4,
+            'title' => 'Loads of fun',
+            'body' => 'Woot'
+        ], $newResource->toArray());
+
+        $invalidResource = new Resource([
+            'id' => 'Hello',
+            'title' => 'Loads of fun',
+            'body' => 'Woot'
+        ]);
+
+        $savedInvalidResource = $this->endpoint->save($invalidResource);
+        $this->assertFalse($savedInvalidResource);
+    }
+
+    public function testUpdatingSave()
+    {
+        $resource = $this->endpoint->get(2);
+
+        $resource->title = 'New ORM for webservices';
+
+        $savedResource = $this->endpoint->save($resource);
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $savedResource);
+        $this->assertFalse($savedResource->isNew());
+
+        $newResource = $this->endpoint->get(2);
+        $this->assertEquals($newResource->title, 'New ORM for webservices');
+    }
+
+    /**
+     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
+     */
+    public function testDelete()
+    {
+        $resource = $this->endpoint->get(2);
+
+        $this->assertTrue($this->endpoint->delete($resource));
+
+        $this->endpoint->get(2);
+    }
+}

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -22,7 +22,6 @@ class TestDriver extends AbstractDriver
      */
     public function initialize()
     {
-        // TODO: Implement initialize() method.
     }
 
     /**

--- a/tests/TestCase/Model/ResourceTest.php
+++ b/tests/TestCase/Model/ResourceTest.php
@@ -25,5 +25,4 @@ class ResourceTest extends TestCase
         ]);
         $this->assertEquals($endpoint, $resource->source());
     }
-
 }

--- a/tests/TestCase/Model/ResourceTest.php
+++ b/tests/TestCase/Model/ResourceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase;
+
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Model\Endpoint;
+use Muffin\Webservice\Model\Resource;
+
+class ResourceTest extends TestCase
+{
+
+    public function testBasicConstruct()
+    {
+        $resource = new Resource([]);
+
+        $this->assertTrue($resource->isNew());
+    }
+
+    public function testSoureConstruct()
+    {
+        $endpoint = new Endpoint();
+
+        $resource = new Resource([], [
+            'source' => $endpoint
+        ]);
+        $this->assertEquals($endpoint, $resource->source());
+    }
+
+}

--- a/tests/TestCase/Model/ResourceTest.php
+++ b/tests/TestCase/Model/ResourceTest.php
@@ -25,4 +25,16 @@ class ResourceTest extends TestCase
         ]);
         $this->assertEquals($endpoint, $resource->source());
     }
+
+    public function testConstructUseSettersOff()
+    {
+        $resource = new Resource([
+            'field' => 'text'
+        ], [
+            'markClean' => true,
+            'useSetters' => false
+        ]);
+
+        $this->assertEquals('text', $resource->get('field'));
+    }
 }

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase;
+
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Model\Endpoint;
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\Query;
+use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Webservice\WebserviceInterface;
+
+class TestWebservice implements WebserviceInterface
+{
+
+    public function execute(Query $query)
+    {
+        return new ResultSet([
+            new Resource([
+                'id' => 1,
+                'title' => 'Hello World'
+            ]),
+            new Resource([
+                'id' => 2,
+                'title' => 'New ORM'
+            ]),
+            new Resource([
+                'id' => 3,
+                'title' => 'Webservices'
+            ])
+        ], 3);
+    }
+}
+
+class QueryTest extends TestCase
+{
+
+    /**
+     * @var Query
+     */
+    public $query;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->query = new Query(new TestWebservice(), new Endpoint());
+    }
+
+    public function testAction()
+    {
+        $this->assertNull($this->query->action());
+
+        $this->assertEquals($this->query, $this->query->action(Query::ACTION_READ));
+        $this->assertEquals(Query::ACTION_READ, $this->query->action());
+    }
+
+    public function testActionMethods()
+    {
+        $this->assertEquals($this->query, $this->query->create());
+        $this->assertEquals(Query::ACTION_CREATE, $this->query->action());
+
+        $this->assertEquals($this->query, $this->query->read());
+        $this->assertEquals(Query::ACTION_READ, $this->query->action());
+
+        $this->assertEquals($this->query, $this->query->update());
+        $this->assertEquals(Query::ACTION_UPDATE, $this->query->action());
+
+        $this->assertEquals($this->query, $this->query->delete());
+        $this->assertEquals(Query::ACTION_DELETE, $this->query->action());
+    }
+
+    public function testCountNonReadAction()
+    {
+        $this->assertEquals(false, $this->query->count());
+    }
+
+    public function testCount()
+    {
+        $this->query->read();
+
+        $this->assertEquals(3, $this->query->count());
+    }
+
+    public function testFirst()
+    {
+        $this->assertEquals(new Resource([
+            'id' => 1,
+            'title' => 'Hello World'
+        ]), $this->query->first());
+    }
+
+    public function testApplyOptions()
+    {
+        $this->assertEquals($this->query, $this->query->applyOptions([
+            'page' => 1,
+            'limit' => 2,
+            'order' => [
+                'field' => 'ASC'
+            ],
+            'customOption' => 'value'
+        ]));
+        $this->assertEquals(1, $this->query->page());
+        $this->assertEquals(2, $this->query->limit());
+        $this->assertEquals([
+            'field' => 'ASC'
+        ], $this->query->order());
+        $this->assertEquals([
+            'customOption' => 'value'
+        ], $this->query->getOptions());
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testSetInvalidAction()
+    {
+        $this->query->read();
+
+        $this->query->set([]);
+    }
+
+    public function testSet()
+    {
+        $this->query->update();
+
+        $this->assertEquals($this->query, $this->query->set([
+            'field' => 'value'
+        ]));
+        $this->assertEquals([
+            'field' => 'value'
+        ], $this->query->set());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->query = null;
+    }
+}

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
+use Muffin\Webservice\ResultSet;
 use Muffin\Webservice\Test\test_app\Webservice\StaticWebservice;
 
 class QueryTest extends TestCase
@@ -161,13 +162,43 @@ class QueryTest extends TestCase
         ], $this->query->clause('order'));
     }
 
+    public function testExecuteTwice()
+    {
+        $mockWebservice = $this
+            ->getMock('\Muffin\Webservice\Test\test_app\Webservice\StaticWebservice', [
+                'execute'
+            ]);
+        $mockWebservice->expects($this->once())
+            ->method('execute')
+            ->will($this->returnValue(new ResultSet([
+                new Resource([
+                    'id' => 1,
+                    'title' => 'Hello World'
+                ]),
+                new Resource([
+                    'id' => 2,
+                    'title' => 'New ORM'
+                ]),
+                new Resource([
+                    'id' => 3,
+                    'title' => 'Webservices'
+                ])
+            ], 3)));
+        $this->query->webservice($mockWebservice);
+
+        $this->query->execute();
+
+        // This webservice shouldn't be called a second time
+        $this->query->execute();
+    }
+
     public function testDebugInfo()
     {
         $this->assertEquals([
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'action' => null,
             'formatters' => [],
-            'offset'  => null,
+            'offset' => null,
             'page' => null,
             'limit' => null,
             'set' => [],

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -106,7 +106,7 @@ class QueryTest extends TestCase
         $this->assertEquals(2, $this->query->limit());
         $this->assertEquals([
             'field' => 'ASC'
-        ], $this->query->order());
+        ], $this->query->clause('order'));
         $this->assertEquals([
             'customOption' => 'value'
         ], $this->query->getOptions());

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -190,6 +190,7 @@ class QueryTest extends TestCase
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'action' => null,
             'formatters' => [],
+            'offset'  => null,
             'page' => null,
             'limit' => null,
             'set' => [],

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -72,6 +72,11 @@ class QueryTest extends TestCase
         $this->assertEquals(Query::ACTION_DELETE, $this->query->action());
     }
 
+    public function testAliasField()
+    {
+        $this->assertEquals(['field' => 'field'], $this->query->aliasField('field'));
+    }
+
     public function testCountNonReadAction()
     {
         $this->assertEquals(false, $this->query->count());
@@ -112,6 +117,18 @@ class QueryTest extends TestCase
         ], $this->query->getOptions());
     }
 
+    public function testFind()
+    {
+        $this->query->endpoint()->primaryKey('id');
+        $this->query->endpoint()->displayField('title');
+
+        $this->assertEquals($this->query, $this->query->find('list'));
+
+        $debugInfo = $this->query->__debugInfo();
+
+        $this->assertInternalType('callable', $debugInfo['formatters'][0]);
+    }
+
     /**
      * @expectedException \UnexpectedValueException
      */
@@ -132,6 +149,56 @@ class QueryTest extends TestCase
         $this->assertEquals([
             'field' => 'value'
         ], $this->query->set());
+    }
+
+    public function testPage()
+    {
+        $this->assertEquals($this->query, $this->query->page(10));
+
+        $this->assertEquals(10, $this->query->clause('page'));
+    }
+
+    public function testPageWithLimit()
+    {
+        $this->assertEquals($this->query, $this->query->page(10, 20));
+
+        $this->assertEquals(10, $this->query->clause('page'));
+        $this->assertEquals(20, $this->query->clause('limit'));
+    }
+
+    public function testOffset()
+    {
+        $this->assertEquals($this->query, $this->query->offset(10));
+
+        $this->assertEquals(10, $this->query->clause('offset'));
+    }
+
+    public function testOrder()
+    {
+        $this->assertEquals($this->query, $this->query->order([
+            'field' => 'ASC'
+        ]));
+
+        $this->assertEquals([
+            'field' => 'ASC'
+        ], $this->query->clause('order'));
+    }
+
+    public function testDebugInfo()
+    {
+        $this->assertEquals([
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
+            'action' => null,
+            'formatters' => [],
+            'page' => null,
+            'limit' => null,
+            'set' => [],
+            'sort' => [],
+            'extraOptions' => [],
+            'conditions' => [],
+            'repository' => new Endpoint(),
+            'webservice' => new TestWebservice()
+        ], $this->query->__debugInfo());
     }
 
     /**

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -12,7 +12,7 @@ use Muffin\Webservice\Webservice\WebserviceInterface;
 class TestWebservice implements WebserviceInterface
 {
 
-    public function execute(Query $query)
+    public function execute(Query $query, array $options = [])
     {
         return new ResultSet([
             new Resource([

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -6,30 +6,7 @@ use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
-use Muffin\Webservice\ResultSet;
-use Muffin\Webservice\Webservice\WebserviceInterface;
-
-class TestWebservice implements WebserviceInterface
-{
-
-    public function execute(Query $query, array $options = [])
-    {
-        return new ResultSet([
-            new Resource([
-                'id' => 1,
-                'title' => 'Hello World'
-            ]),
-            new Resource([
-                'id' => 2,
-                'title' => 'New ORM'
-            ]),
-            new Resource([
-                'id' => 3,
-                'title' => 'Webservices'
-            ])
-        ], 3);
-    }
-}
+use Muffin\Webservice\Test\test_app\Webservice\StaticWebservice;
 
 class QueryTest extends TestCase
 {
@@ -46,7 +23,7 @@ class QueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = new Query(new TestWebservice(), new Endpoint());
+        $this->query = new Query(new StaticWebservice(), new Endpoint());
     }
 
     public function testAction()
@@ -198,7 +175,7 @@ class QueryTest extends TestCase
             'extraOptions' => [],
             'conditions' => [],
             'repository' => new Endpoint(),
-            'webservice' => new TestWebservice()
+            'webservice' => new StaticWebservice()
         ], $this->query->__debugInfo());
     }
 

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -47,6 +47,18 @@ class ResultSetTest extends TestCase
         $this->assertEquals(6, $this->resultSet->total());
     }
 
+    public function testSerialize()
+    {
+        $this->assertInternalType('string', serialize($this->resultSet));
+    }
+
+    public function testUnserialize()
+    {
+        $unserialized = unserialize(serialize($this->resultSet));
+
+        $this->assertInstanceOf('\Muffin\Webservice\ResultSet', $unserialized);
+    }
+
     /**
      * @inheritDoc
      */

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase;
+
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\ResultSet;
+
+class ResultSetTest extends TestCase
+{
+
+    /**
+     * @var ResultSet
+     */
+    public $resultSet;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->resultSet = new ResultSet([
+            new Resource([
+                'id' => 1,
+                'title' => 'Hello World'
+            ]),
+            new Resource([
+                'id' => 2,
+                'title' => 'New ORM'
+            ]),
+            new Resource([
+                'id' => 3,
+                'title' => 'Webservices'
+            ])
+        ], 6);
+    }
+
+    public function testCount()
+    {
+        $this->assertEquals(3, $this->resultSet->count());
+    }
+
+    public function testTotal()
+    {
+        $this->assertEquals(6, $this->resultSet->total());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->resultSet = null;
+    }
+}

--- a/tests/TestCase/Webservice/WebserviceTest.php
+++ b/tests/TestCase/Webservice/WebserviceTest.php
@@ -6,22 +6,8 @@ use Cake\Log\Engine\ConsoleLog;
 use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Query;
-use Muffin\Webservice\Test\TestCase\Model\TestDriver;
-use Muffin\Webservice\Webservice\Webservice;
-
-class TestWebservice extends Webservice
-{
-
-    public function createResource($resourceClass, array $properties = [])
-    {
-        return $this->_createResource($resourceClass, $properties);
-    }
-
-    public function transformResults(array $results, $resourceClass)
-    {
-        return $this->_transformResults($results, $resourceClass);
-    }
-}
+use Muffin\Webservice\Test\test_app\Webservice\Driver\Test;
+use Muffin\Webservice\Test\test_app\Webservice\TestWebservice;
 
 class WebserviceTest extends TestCase
 {
@@ -39,13 +25,13 @@ class WebserviceTest extends TestCase
         parent::setUp();
 
         $this->webservice = new TestWebservice([
-            'driver' => new TestDriver([])
+            'driver' => new Test([])
         ]);
     }
 
     public function testConstructor()
     {
-        $testDriver = new TestDriver([]);
+        $testDriver = new Test([]);
 
         $webservice = new TestWebservice([
             'driver' => $testDriver,
@@ -117,7 +103,7 @@ class WebserviceTest extends TestCase
 
     /**
      * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
-     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeCreateQuery
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\test_app\Webservice\TestWebservice does not implement _executeCreateQuery
      */
     public function testExecuteWithoutCreate()
     {
@@ -129,7 +115,7 @@ class WebserviceTest extends TestCase
 
     /**
      * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
-     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeReadQuery
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\test_app\Webservice\TestWebservice does not implement _executeReadQuery
      */
     public function testExecuteWithoutRead()
     {
@@ -141,7 +127,7 @@ class WebserviceTest extends TestCase
 
     /**
      * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
-     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeUpdateQuery
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\test_app\Webservice\TestWebservice does not implement _executeUpdateQuery
      */
     public function testExecuteWithoutUpdate()
     {
@@ -153,7 +139,7 @@ class WebserviceTest extends TestCase
 
     /**
      * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
-     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeDeleteQuery
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\test_app\Webservice\TestWebservice does not implement _executeDeleteQuery
      */
     public function testExecuteWithoutDelete()
     {

--- a/tests/TestCase/Webservice/WebserviceTest.php
+++ b/tests/TestCase/Webservice/WebserviceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase\Webservice;
+
+use Cake\Log\Engine\ConsoleLog;
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Model\Endpoint;
+use Muffin\Webservice\Query;
+use Muffin\Webservice\Test\TestCase\Model\TestDriver;
+use Muffin\Webservice\Webservice\Webservice;
+
+class TestWebservice extends Webservice
+{
+
+    public function createResource($resourceClass, array $properties = [])
+    {
+        return $this->_createResource($resourceClass, $properties);
+    }
+
+    public function transformResults(array $results, $resourceClass)
+    {
+        return $this->_transformResults($results, $resourceClass);
+    }
+}
+
+class WebserviceTest extends TestCase
+{
+
+    /**
+     * @var \Muffin\Webservice\Webservice\Webservice
+     */
+    public $webservice;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->webservice = new TestWebservice([
+            'driver' => new TestDriver([])
+        ]);
+    }
+
+    public function testConstructor()
+    {
+        $testDriver = new TestDriver([]);
+
+        $webservice = new TestWebservice([
+            'driver' => $testDriver,
+            'endpoint' => 'test'
+        ]);
+
+        $this->assertEquals($testDriver, $webservice->driver());
+        $this->assertEquals('test', $webservice->endpoint());
+    }
+
+    public function testNestedResources()
+    {
+        $this->webservice->addNestedResource('/authors/:author_id/articles', [
+            'author_id'
+        ]);
+        $this->webservice->addNestedResource('/articles/:date', [
+            'date'
+        ]);
+
+        $this->assertEquals('/authors/10/articles', $this->webservice->nestedResource([
+            'author_id' => 10
+        ]));
+        $this->assertEquals('/articles/16-10-2015', $this->webservice->nestedResource([
+            'date' => '16-10-2015'
+        ]));
+        $this->assertFalse($this->webservice->nestedResource([
+            'title' => 'hello'
+        ]));
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage No driver has been defined
+     */
+    public function testExecuteWithoutDriver()
+    {
+        $webservice = new TestWebservice();
+
+        $query = new Query($webservice, new Endpoint());
+
+        $webservice->execute($query);
+    }
+
+    public function testExecuteLoggingWithoutLogger()
+    {
+        $query = new Query($this->webservice, new Endpoint());
+
+        $this->webservice->execute($query);
+    }
+
+    public function testExecuteLoggingWithLogger()
+    {
+        $this->webservice->driver()->setLogger(new ConsoleLog());
+
+        $query = new Query($this->webservice, new Endpoint());
+
+        $this->webservice->execute($query);
+    }
+
+    public function testExecuteLoggingWithLoggerEnabled()
+    {
+        $this->webservice->driver()->logQueries(true);
+        $this->webservice->driver()->setLogger(new ConsoleLog());
+
+        $query = new Query($this->webservice, new Endpoint());
+
+        $this->webservice->execute($query);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeCreateQuery
+     */
+    public function testExecuteWithoutCreate()
+    {
+        $query = new Query($this->webservice, new Endpoint());
+        $query->create();
+
+        $this->webservice->execute($query);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeReadQuery
+     */
+    public function testExecuteWithoutRead()
+    {
+        $query = new Query($this->webservice, new Endpoint());
+        $query->read();
+
+        $this->webservice->execute($query);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeUpdateQuery
+     */
+    public function testExecuteWithoutUpdate()
+    {
+        $query = new Query($this->webservice, new Endpoint());
+        $query->update();
+
+        $this->webservice->execute($query);
+    }
+
+    /**
+     * @expectedException \Muffin\Webservice\Exception\UnimplementedWebserviceMethodException
+     * @expectedExceptionMessage Webservice Muffin\Webservice\Test\TestCase\Webservice\TestWebservice does not implement _executeDeleteQuery
+     */
+    public function testExecuteWithoutDelete()
+    {
+        $query = new Query($this->webservice, new Endpoint());
+        $query->delete();
+
+        $this->webservice->execute($query);
+    }
+
+    public function testCreateResource()
+    {
+        /* @var \Muffin\Webservice\Model\Resource $resource */
+        $resource = $this->webservice->createResource('\Muffin\Webservice\Model\Resource', []);
+
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $resource);
+        $this->assertFalse($resource->isNew());
+        $this->assertFalse($resource->dirty());
+    }
+
+    public function testTransformResults()
+    {
+        $resources = $this->webservice->transformResults([
+            [
+                'id' => 1,
+                'title' => 'Hello World',
+                'body' => 'Some text'
+            ],
+            [
+                'id' => 2,
+                'title' => 'New ORM',
+                'body' => 'Some more text'
+            ],
+            [
+                'id' => 3,
+                'title' => 'Webservices',
+                'body' => 'Even more text'
+            ]
+        ], '\Muffin\Webservice\Model\Resource');
+
+        $this->assertInternalType('array', $resources);
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $resources[0]);
+    }
+
+    public function testDebugInfo()
+    {
+        $this->assertEquals([
+            'driver' => $this->webservice->driver(),
+            'endpoint' => $this->webservice->endpoint()
+        ], $this->webservice->__debugInfo());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($this->webservice);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,7 +38,7 @@ $loader = new \Cake\Core\ClassLoader;
 $loader->register();
 
 $loader->addNamespace('TestApp', APP);
-$loader->addNamespace('SomeVendor\SomePlugin', APP . 'plugins' . DS . 'SomeVendor'. DS . 'SomePlugin'. DS . 'src');
+$loader->addNamespace('SomeVendor\SomePlugin', APP . 'plugins' . DS . 'SomeVendor' . DS . 'SomePlugin' . DS . 'src');
 
 require_once CORE_PATH . 'config/bootstrap.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,8 @@ $root = $findRoot(__FILE__);
 unset($findRoot);
 
 chdir($root);
+
+require $root . '/vendor/autoload.php';
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,7 +38,7 @@ $loader = new \Cake\Core\ClassLoader;
 $loader->register();
 
 $loader->addNamespace('TestApp', APP);
-$loader->addNamespace('SomeVendor\SomePlugin', APP . 'plugins' . DS . 'SomeVendor'  . DS . 'SomePlugin'. DS . 'src');
+$loader->addNamespace('SomeVendor\SomePlugin', APP . 'plugins' . DS . 'SomeVendor'. DS . 'SomePlugin'. DS . 'src');
 
 require_once CORE_PATH . 'config/bootstrap.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,32 +1,119 @@
 <?php
 /**
- * Test suite bootstrap.
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
- * This function is used to find the location of CakePHP whether CakePHP
- * has been installed as a dependency of the plugin, or the plugin is itself
- * installed as a dependency of an application.
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-$findRoot = function ($root) {
-    do {
-        $lastRoot = $root;
-        $root = dirname($root);
-        if (is_dir($root . '/vendor/cakephp/cakephp')) {
-            return $root;
-        }
-    } while ($root !== $lastRoot);
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
+use Cake\Log\Log;
+use Cake\Routing\DispatcherFactory;
 
-    throw new Exception("Cannot find the root of the application, unable to run tests");
-};
-$root = $findRoot(__FILE__);
-unset($findRoot);
+require_once 'vendor/autoload.php';
 
-chdir($root);
+// Path constants to a few helpful things.
+define('ROOT', dirname(__DIR__) . DS);
+define('CAKE_CORE_INCLUDE_PATH', ROOT . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
+define('CORE_PATH', ROOT . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+define('CAKE', CORE_PATH . 'src' . DS);
+define('TESTS', ROOT . 'tests');
+define('APP', ROOT . 'tests' . DS . 'test_app' . DS);
+define('APP_DIR', 'test_app');
+define('WEBROOT_DIR', 'webroot');
+define('WWW_ROOT', APP . 'webroot' . DS);
+define('TMP', sys_get_temp_dir() . DS);
+define('CONFIG', APP . 'config' . DS);
+define('CACHE', TMP);
+define('LOGS', TMP);
 
-require $root . '/vendor/autoload.php';
-if (file_exists($root . '/config/bootstrap.php')) {
-    require $root . '/config/bootstrap.php';
+$loader = new \Cake\Core\ClassLoader;
+$loader->register();
+
+$loader->addNamespace('TestApp', APP);
+$loader->addNamespace('SomeVendor\SomePlugin', APP . 'plugins' . DS . 'SomeVendor'  . DS . 'SomePlugin'. DS . 'src');
+
+require_once CORE_PATH . 'config/bootstrap.php';
+
+date_default_timezone_set('UTC');
+mb_internal_encoding('UTF-8');
+
+Configure::write('debug', true);
+Configure::write('App', [
+    'namespace' => 'Muffin\\Webservice\\Test\\test_app',
+    'encoding' => 'UTF-8',
+    'base' => false,
+    'baseUrl' => false,
+    'dir' => 'src',
+    'webroot' => 'webroot',
+    'www_root' => APP . 'webroot',
+    'fullBaseUrl' => 'http://localhost',
+    'imageBaseUrl' => 'img/',
+    'jsBaseUrl' => 'js/',
+    'cssBaseUrl' => 'css/',
+    'paths' => [
+        'plugins' => [APP . 'Plugin' . DS],
+        'templates' => [APP . 'Template' . DS]
+    ]
+]);
+Configure::write('Session', [
+    'defaults' => 'php'
+]);
+
+Cache::config([
+    '_cake_core_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_core_',
+        'serialize' => true
+    ],
+    '_cake_model_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_model_',
+        'serialize' => true
+    ],
+    'default' => [
+        'engine' => 'File',
+        'prefix' => 'default_',
+        'serialize' => true
+    ]
+]);
+
+// Ensure default test connection is defined
+if (!getenv('db_dsn')) {
+    putenv('db_dsn=sqlite:/' . TMP . 'debug_kit_test.sqlite');
 }
 
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+$config = [
+    'url' => getenv('db_dsn'),
+    'timezone' => 'UTC',
+];
 
-\Cake\Core\Plugin::load('Muffin/Webservice', ['path' => dirname(dirname(__FILE__)) . DS]);
+// Use the test connection for 'debug_kit' as well.
+ConnectionManager::config('test', $config);
+ConnectionManager::config('test_webservice', $config);
+
+
+Log::config([
+    'debug' => [
+        'engine' => 'Cake\Log\Engine\FileLog',
+        'levels' => ['notice', 'info', 'debug'],
+        'file' => 'debug',
+    ],
+    'error' => [
+        'engine' => 'Cake\Log\Engine\FileLog',
+        'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+        'file' => 'error',
+    ]
+]);
+
+Plugin::load('DebugKit', ['path' => ROOT, 'bootstrap' => true]);
+
+DispatcherFactory::add('Routing');
+DispatcherFactory::add('ControllerFactory');

--- a/tests/test_app/Model/Endpoint/AppEndpoint.php
+++ b/tests/test_app/Model/Endpoint/AppEndpoint.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Model\Endpoint;
+
+use Muffin\Webservice\Model\Endpoint;
+
+class AppEndpoint extends Endpoint
+{
+
+}

--- a/tests/test_app/Model/Endpoint/TestEndpoint.php
+++ b/tests/test_app/Model/Endpoint/TestEndpoint.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Model\Endpoint;
+
+use Cake\Validation\Validator;
+use Muffin\Webservice\Model\Endpoint;
+
+class TestEndpoint extends Endpoint
+{
+
+
+    /**
+     * Returns the default validator object. Subclasses can override this function
+     * to add a default validation set to the validator object.
+     *
+     * @param \Cake\Validation\Validator $validator The validator that can be modified to
+     * add some rules to it.
+     *
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator->requirePresence('title')
+            ->notEmpty('title')
+            ->requirePresence('body')
+            ->notEmpty('body');
+
+        return $validator;
+    }
+}

--- a/tests/test_app/Webservice/Driver/Test.php
+++ b/tests/test_app/Webservice/Driver/Test.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Webservice\Driver;
+
+use Muffin\Webservice\AbstractDriver;
+use Muffin\Webservice\Test\test_app\Webservice\EndpointTestWebservice;
+
+class Test extends AbstractDriver
+{
+
+    /**
+     * Initialize is used to easily extend the constructor.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _createWebservice($className, array $options = [])
+    {
+        return new EndpointTestWebservice($options);
+    }
+}

--- a/tests/test_app/Webservice/EndpointTestWebservice.php
+++ b/tests/test_app/Webservice/EndpointTestWebservice.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Webservice;
+
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\Query;
+use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Webservice\Webservice;
+
+class EndpointTestWebservice extends Webservice
+{
+
+    public $resources;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->resources = [
+            new Resource([
+                'id' => 1,
+                'title' => 'Hello World',
+                'body' => 'Some text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ]),
+            new Resource([
+                'id' => 2,
+                'title' => 'New ORM',
+                'body' => 'Some more text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ]),
+            new Resource([
+                'id' => 3,
+                'title' => 'Webservices',
+                'body' => 'Even more text'
+            ], [
+                'markNew' => false,
+                'markClean' => true
+            ])
+        ];
+    }
+
+
+    protected function _executeCreateQuery(Query $query, array $options = [])
+    {
+        $fields = $query->set();
+
+        if (!is_numeric($fields['id'])) {
+            return false;
+        }
+
+        $this->resources[] = new Resource($fields, [
+            'markNew' => false,
+            'markClean' => true
+        ]);
+
+        return true;
+    }
+
+    protected function _executeReadQuery(Query $query, array $options = [])
+    {
+        if (!empty($query->where()['id'])) {
+            $index = $this->conditionsToIndex($query->where());
+
+            if (!isset($this->resources[$index])) {
+                return new ResultSet([], 0);
+            }
+
+            return new ResultSet([
+                $this->resources[$index]
+            ], 1);
+        }
+        if (isset($query->where()[$query->endpoint()->aliasField('title')])) {
+            $resources = [];
+
+            foreach ($this->resources as $resource) {
+                if ($resource->title !== $query->where()[$query->endpoint()->aliasField('title')]) {
+                    continue;
+                }
+
+                $resources[] = $resource;
+            }
+
+            return new ResultSet($resources, count($resources));
+        }
+
+        return new ResultSet($this->resources, count($this->resources));
+    }
+
+    protected function _executeUpdateQuery(Query $query, array $options = [])
+    {
+        $this->resources[$this->conditionsToIndex($query->where())]->set($query->set());
+
+        $this->resources[$this->conditionsToIndex($query->where())]->clean();
+
+        return 1;
+    }
+
+    protected function _executeDeleteQuery(Query $query, array $options = [])
+    {
+        $conditions = $query->where();
+
+        if (is_int($conditions['id'])) {
+            $exists = isset($this->resources[$this->conditionsToIndex($conditions)]);
+
+            unset($this->resources[$this->conditionsToIndex($conditions)]);
+
+            return ($exists) ? 1 : 0;
+        } elseif (is_array($conditions['id'])) {
+            $deleted = 0;
+
+            foreach ($conditions['id'] as $id) {
+                if (!isset($this->resources[$id - 1])) {
+                    continue;
+                }
+
+                $deleted++;
+                unset($this->resources[$id - 1]);
+            }
+
+            return $deleted;
+        }
+
+        return 0;
+    }
+
+    public function conditionsToIndex(array $conditions)
+    {
+        return $conditions['id'] - 1;
+    }
+}

--- a/tests/test_app/Webservice/StaticWebservice.php
+++ b/tests/test_app/Webservice/StaticWebservice.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Webservice;
+
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\Query;
+use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Webservice\WebserviceInterface;
+
+class StaticWebservice implements WebserviceInterface
+{
+
+    public function execute(Query $query, array $options = [])
+    {
+        return new ResultSet([
+            new Resource([
+                'id' => 1,
+                'title' => 'Hello World'
+            ]),
+            new Resource([
+                'id' => 2,
+                'title' => 'New ORM'
+            ]),
+            new Resource([
+                'id' => 3,
+                'title' => 'Webservices'
+            ])
+        ], 3);
+    }
+}

--- a/tests/test_app/Webservice/TestWebservice.php
+++ b/tests/test_app/Webservice/TestWebservice.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Webservice;
+
+use Muffin\Webservice\Webservice\Webservice;
+
+class TestWebservice extends Webservice
+{
+
+    public function createResource($resourceClass, array $properties = [])
+    {
+        return $this->_createResource($resourceClass, $properties);
+    }
+
+    public function transformResults(array $results, $resourceClass)
+    {
+        return $this->_transformResults($results, $resourceClass);
+    }
+}

--- a/tests/test_app/plugins/SomeVendor/SomePlugin/src/Model/Endpoint/PluginEndpoint.php
+++ b/tests/test_app/plugins/SomeVendor/SomePlugin/src/Model/Endpoint/PluginEndpoint.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SomeVendor\SomePlugin\Model\Endpoint;
+
+use Muffin\Webservice\Model\Endpoint;
+
+class PluginEndpoint extends Endpoint
+{
+
+}


### PR DESCRIPTION
This pull request adds a mini ORM to allow easy querying, updating, deleting, creating of resources on a remote API.

To do this it implements a few classes:
* ```Webservice``` This is the part that communicates with the actual API
* ```Endpoint``` This is what you use to start querying (CakePHP equivalent is ```Table```)
* ```Resource``` This is a resource returned by the API (CakePHP equivalent is ```Entity```)

In order to make it easy to use these ```Endpoints``` it adds a modelFactory to the controller. This allows you to load Endpoints like this:
```php
    public function beforeFilter(Event $event)
    {
        $this->loadModel('CvoTechnologies/GitHub.Issues', 'Endpoint');
    }
```

I'm working on https://github.com/cvo-technologies/cakephp-github as a example plugin that uses this ORM.
