### PR TITLE
Endpoint schema

### DIFF
--- a/src/Exception/MissingEndpointSchemaException.php
+++ b/src/Exception/MissingEndpointSchemaException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Muffin\Webservice\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class MissingEndpointSchemaException extends Exception
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_messageTemplate = 'Missing schema %s or webservice %s discribe implementation';
+}

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -21,6 +21,7 @@ use Muffin\Webservice\Exception\MissingResourceClassException;
 use Muffin\Webservice\Exception\UnexpectedDriverException;
 use Muffin\Webservice\Marshaller;
 use Muffin\Webservice\Query;
+use Muffin\Webservice\Schema;
 use Muffin\Webservice\StreamQuery;
 
 /**
@@ -298,10 +299,45 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
     public function schema($schema = null)
     {
         if ($schema === null) {
+            if ($this->_schema === null) {
+                $this->_schema = $this->_initializeSchema(
+                    $this->webservice()
+                        ->describe($this->endpoint())
+                );
+            }
             return $this->_schema;
         }
-
+        if (is_array($schema)) {
+            $schema = new Schema($this->table(), $schema);
+        }
         return $this->_schema = $schema;
+    }
+
+    /**
+     * Override this function in order to alter the schema used by this endpoint.
+     * This function is only called after fetching the schema out of the webservice.
+     * If you wish to provide your own schema to this table without touching the
+     * database, you can override schema() or inject the definitions though that
+     * method.
+     *
+     * ### Example:
+     *
+     * ```
+     * protected function _initializeSchema(\Muffin\Webservice\Schema $schema) {
+     *  $schema->addColumn('preferences', [
+     *   'type' => 'string'
+     *  ]);
+     *  return $schema;
+     * }
+     * ```
+     *
+     * @param \Muffin\Webservice\Schema $schema The schema definition fetched from webservice.
+     * @return \Muffin\Webservice\Schema the altered schema
+     * @api
+     */
+    protected function _initializeSchema(Schema $schema)
+    {
+        return $schema;
     }
 
     /**

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -808,24 +808,16 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
             return false;
         }
 
+        $data = $resource->extract($this->schema()->columns(), true);
+
         if ($resource->isNew()) {
-            $query = $this->query()->create()->set($resource->toArray());
+            $query = $this->query()->create();
         } else {
             $query = $this->query()->update()->where([
                 $this->primaryKey() => $resource->get($this->primaryKey())
             ]);
-
-            $fieldsToUpdate = [];
-            foreach ($resource as $field => $value) {
-                if (!$resource->dirty($field)) {
-                    continue;
-                }
-
-                $fieldsToUpdate[$field] = $value;
-            }
-
-            $query->set($fieldsToUpdate);
         }
+        $query->set($data);
 
         $result = $query->execute();
         if (!$result) {

--- a/src/Model/Schema.php
+++ b/src/Model/Schema.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+class Schema extends \Muffin\Webservice\Schema
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string $endpoint The endpoint name.
+     * @param array $fields The list of fields for the schema.
+     */
+    public function __construct($endpoint, array $fields = [])
+    {
+        parent::__construct($endpoint, $fields);
+
+        $this->initialize();
+    }
+
+    /**
+     * Initialize a schema instance. Called after the constructor.
+     *
+     * You can use this method to define fields.
+     *
+     * ```
+     *  public function initialize()
+     *  {
+     *      $this->addField('title', [
+     *          'type' => 'string'
+     *      ]);
+     *  }
+     * ```
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+    }
+}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -2,41 +2,327 @@
 
 namespace Muffin\Webservice;
 
-use Cake\Database\Schema\Table;
-
-class Schema extends Table
+/**
+ * Represents a single endpoint in a database schema.
+ *
+ * Can either be populated using the reflection API's
+ * or by incrementally building an instance using
+ * methods.
+ */
+class Schema
 {
+
+    /**
+     * The name of the endpoint
+     *
+     * @var string
+     */
+    protected $_repository;
+
+    /**
+     * Columns in the endpoint.
+     *
+     * @var array
+     */
+    protected $_columns = [];
+
+    /**
+     * A map with columns to types
+     *
+     * @var array
+     */
+    protected $_typeMap = [];
+
+    /**
+     * Indexes in the endpoint.
+     *
+     * @var array
+     */
+    protected $_indexes = [];
+
+    /**
+     * Constraints in the endpoint.
+     *
+     * @var array
+     */
+    protected $_constraints = [];
+
+    /**
+     * Options for the endpoint.
+     *
+     * @var array
+     */
+    protected $_options = [];
+
+    /**
+     * Whether or not the endpoint is temporary
+     *
+     * @var bool
+     */
+    protected $_temporary = false;
+
+    /**
+     * The valid keys that can be used in a column
+     * definition.
+     *
+     * @var array
+     */
+    protected static $_columnKeys = [
+        'type' => null,
+        'baseType' => null,
+        'length' => null,
+        'precision' => null,
+        'null' => null,
+        'default' => null,
+        'comment' => null,
+    ];
+
+    /**
+     * Additional type specific properties.
+     *
+     * @var array
+     */
+    protected static $_columnExtras = [
+        'string' => [
+            'fixed' => null,
+        ],
+        'integer' => [
+            'unsigned' => null,
+            'autoIncrement' => null,
+        ],
+        'biginteger' => [
+            'unsigned' => null,
+            'autoIncrement' => null,
+        ],
+        'decimal' => [
+            'unsigned' => null,
+        ],
+        'float' => [
+            'unsigned' => null,
+        ],
+    ];
 
     /**
      * Constructor.
      *
      * @param string $endpoint The endpoint name.
-     * @param array $fields The list of fields for the schema.
+     * @param array $columns The list of columns for the schema.
      */
-    public function __construct($endpoint, array $fields = [])
+    public function __construct($endpoint, array $columns = [])
     {
-        parent::__construct($endpoint, $fields);
-
-        $this->initialize();
+        $this->_repository = $endpoint;
+        foreach ($columns as $field => $definition) {
+            $this->addColumn($field, $definition);
+        }
     }
 
     /**
-     * Initialize a schema instance. Called after the constructor.
+     * Get the name of the endpoint.
      *
-     * You can use this method to define fields.
-     *
-     * ```
-     *  public function initialize()
-     *  {
-     *      $this->addField('title', [
-     *          'type' => 'string'
-     *      ]);
-     *  }
-     * ```
-     *
-     * @return void
+     * @return string
      */
-    public function initialize()
+    public function name()
     {
+        return $this->_repository;
+    }
+
+    /**
+     * Add a column to the endpoint.
+     *
+     * ### Attributes
+     *
+     * Columns can have several attributes:
+     *
+     * - `type` The type of the column. This should be
+     *   one of CakePHP's abstract types.
+     * - `length` The length of the column.
+     * - `precision` The number of decimal places to store
+     *   for float and decimal types.
+     * - `default` The default value of the column.
+     * - `null` Whether or not the column can hold nulls.
+     * - `fixed` Whether or not the column is a fixed length column.
+     *   This is only present/valid with string columns.
+     * - `unsigned` Whether or not the column is an unsigned column.
+     * - `primaryKey` Whether or not the column is a primary key.
+     *   This is only present/valid for integer, decimal, float columns.
+     *
+     * In addition to the above keys, the following keys are
+     * implemented in some database dialects, but not all:
+     *
+     * - `comment` The comment for the column.
+     *
+     * @param string $name The name of the column
+     * @param array $attrs The attributes for the column.
+     * @return $this
+     */
+    public function addColumn($name, $attrs)
+    {
+        if (is_string($attrs)) {
+            $attrs = ['type' => $attrs];
+        }
+        $valid = static::$_columnKeys;
+        if (isset(static::$_columnExtras[$attrs['type']])) {
+            $valid += static::$_columnExtras[$attrs['type']];
+        }
+        $attrs = array_intersect_key($attrs, $valid);
+        $this->_columns[$name] = $attrs + $valid;
+        $this->_typeMap[$name] = $this->_columns[$name]['type'];
+        return $this;
+    }
+
+    /**
+     * Get the column names in the endpoint.
+     *
+     * @return array
+     */
+    public function columns()
+    {
+        return array_keys($this->_columns);
+    }
+
+    /**
+     * Get column data in the endpoint.
+     *
+     * @param string $name The column name.
+     * @return array|null Column data or null.
+     */
+    public function column($name)
+    {
+        if (!isset($this->_columns[$name])) {
+            return null;
+        }
+        $column = $this->_columns[$name];
+        unset($column['baseType']);
+        return $column;
+    }
+
+    /**
+     * Sets the type of a column, or returns its current type
+     * if none is passed.
+     *
+     * @param string $name The column to get the type of.
+     * @param string $type The type to set the column to.
+     * @return string|null Either the column type or null.
+     */
+    public function columnType($name, $type = null)
+    {
+        if (!isset($this->_columns[$name])) {
+            return null;
+        }
+        if ($type !== null) {
+            $this->_columns[$name]['type'] = $type;
+            $this->_typeMap[$name] = $type;
+        }
+        return $this->_columns[$name]['type'];
+    }
+
+    /**
+     * Returns the base type name for the provided column.
+     * This represent the schema type a more complex class is
+     * based upon.
+     *
+     * @param string $column The column name to get the base type from
+     * @return string The base type name
+     */
+    public function baseColumnType($column)
+    {
+        if (isset($this->_columns[$column]['baseType'])) {
+            return $this->_columns[$column]['baseType'];
+        }
+
+        $type = $this->columnType($column);
+
+        if ($type === null) {
+            return null;
+        }
+
+        if (Type::map($type)) {
+            $type = Type::build($type)->getBaseType();
+        }
+        return $this->_columns[$column]['baseType'] = $type;
+    }
+
+    /**
+     * Returns an array where the keys are the column names in the schema
+     * and the values the schema type they have.
+     *
+     * @return array
+     */
+    public function typeMap()
+    {
+        return $this->_typeMap;
+    }
+
+    /**
+     * Check whether or not a field is nullable
+     *
+     * Missing columns are nullable.
+     *
+     * @param string $name The column to get the type of.
+     * @return bool Whether or not the field is nullable.
+     */
+    public function isNullable($name)
+    {
+        if (!isset($this->_columns[$name])) {
+            return true;
+        }
+        return ($this->_columns[$name]['null'] === true);
+    }
+
+    /**
+     * Get a hash of columns and their default values.
+     *
+     * @return array
+     */
+    public function defaultValues()
+    {
+        $defaults = [];
+        foreach ($this->_columns as $name => $data) {
+            if (!array_key_exists('default', $data)) {
+                continue;
+            }
+            if ($data['default'] === null && $data['null'] !== true) {
+                continue;
+            }
+            $defaults[$name] = $data['default'];
+        }
+        return $defaults;
+    }
+
+    /**
+     * Get the column(s) used for the primary key.
+     *
+     * @return array Column name(s) for the primary key. An
+     *   empty list will be returned when the endpoint has no primary key.
+     */
+    public function primaryKey()
+    {
+        $primaryKeys = [];
+        foreach ($this->_columns as $name => $data) {
+            if ((!array_key_exists('primaryKey', $data)) || ($data['primaryKey'] !== true)) {
+                continue;
+            }
+
+            $primaryKeys[] = $name;
+        }
+
+        return [];
+    }
+
+    /**
+     * Get/set the options for a endpoint.
+     *
+     * Endpoint options allow you to set platform specific endpoint level options.
+     *
+     * @param array|null $options The options to set, or null to read options.
+     * @return $this|array Either the endpoint instance, or an array of options when reading.
+     */
+    public function options($options = null)
+    {
+        if ($options === null) {
+            return $this->_options;
+        }
+        $this->_options = array_merge($this->_options, $options);
+        return $this;
     }
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -7,4 +7,36 @@ use Cake\Database\Schema\Table;
 class Schema extends Table
 {
 
+    /**
+     * Constructor.
+     *
+     * @param string $endpoint The endpoint name.
+     * @param array $fields The list of fields for the schema.
+     */
+    public function __construct($endpoint, array $fields = [])
+    {
+        parent::__construct($endpoint, $fields);
+
+        $this->initialize();
+    }
+
+    /**
+     * Initialize a schema instance. Called after the constructor.
+     *
+     * You can use this method to define fields.
+     *
+     * ```
+     *  public function initialize()
+     *  {
+     *      $this->addField('title', [
+     *          'type' => 'string'
+     *      ]);
+     *  }
+     * ```
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+    }
 }

--- a/src/Webservice/WebserviceInterface.php
+++ b/src/Webservice/WebserviceInterface.php
@@ -21,4 +21,12 @@ interface WebserviceInterface
      * @return \Muffin\Webservice\ResultSet|int|bool
      */
     public function execute(Query $query, array $options = []);
+
+    /**
+     * Returns a schema for the provided endpoint
+     *
+     * @param string $endpoint The endpoint to get the schema for
+     * @return \Muffin\Webservice\Schema The schema to use
+     */
+    public function describe($endpoint);
 }

--- a/tests/test_app/Model/Endpoint/Schema/TestSchema.php
+++ b/tests/test_app/Model/Endpoint/Schema/TestSchema.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Model\Endpoint\Schema;
+
+use Muffin\Webservice\Schema;
+
+class TestSchema extends Schema
+{
+
+    public function initialize()
+    {
+        $this->addColumn('id', [
+            'type' => 'int'
+        ]);
+        $this->addColumn('title', [
+            'type' => 'string'
+        ]);
+        $this->addColumn('body', [
+            'type' => 'string'
+        ]);
+    }
+}

--- a/tests/test_app/Model/Endpoint/Schema/TestSchema.php
+++ b/tests/test_app/Model/Endpoint/Schema/TestSchema.php
@@ -2,7 +2,7 @@
 
 namespace Muffin\Webservice\Test\test_app\Model\Endpoint\Schema;
 
-use Muffin\Webservice\Schema;
+use Muffin\Webservice\Model\Schema;
 
 class TestSchema extends Schema
 {

--- a/tests/test_app/Webservice/EndpointTestWebservice.php
+++ b/tests/test_app/Webservice/EndpointTestWebservice.php
@@ -5,6 +5,7 @@ namespace Muffin\Webservice\Test\test_app\Webservice;
 use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Schema;
 use Muffin\Webservice\Webservice\Webservice;
 
 class EndpointTestWebservice extends Webservice

--- a/tests/test_app/Webservice/StaticWebservice.php
+++ b/tests/test_app/Webservice/StaticWebservice.php
@@ -5,6 +5,7 @@ namespace Muffin\Webservice\Test\test_app\Webservice;
 use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\ResultSet;
+use Muffin\Webservice\Schema;
 use Muffin\Webservice\Webservice\WebserviceInterface;
 
 class StaticWebservice implements WebserviceInterface
@@ -26,5 +27,17 @@ class StaticWebservice implements WebserviceInterface
                 'title' => 'Webservices'
             ])
         ], 3);
+    }
+
+    public function describe($endpoint)
+    {
+        return new Schema($endpoint, [
+           'id' => [
+               'type' => 'integer'
+           ],
+            'title' => [
+                'type' => 'string'
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
This change allows you to define a `Schema` for a `Endpoint` in the `Model\Endpoint\Schema` namespace. This allows for more fine grain control over types in for example `_transformResource` but it also improves creation and updating of remote resources as its now able to update actual fields and not including virtual fields.