### PR TITLE
Don't force config when it can be empty

### DIFF
--- a/src/AbstractDriver.php
+++ b/src/AbstractDriver.php
@@ -41,9 +41,12 @@ abstract class AbstractDriver implements LoggerAwareInterface
      *
      * @param array $config Custom configuration.
      */
-    public function __construct($config)
+    public function __construct($config = [])
     {
-        $this->config($config);
+        if (!empty($config)) {
+            $this->config($config);            
+        }
+        
         $this->initialize();
     }
 


### PR DESCRIPTION
This change prevents you having to call the driver class as `$this->driver(new ExampleDriver([])` and writing an empty config value.
