### PR TITLE
Preserve the pagination data in the result set

### DIFF
--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -49,8 +49,8 @@ class ResultSet implements ResultSetInterface
      * Construct the ResultSet
      *
      * @param array $resources The resources to attach
-     * @param array $total Array of pagination data
-     * @param null $pagination The total amount of resources available
+     * @param int $total The total amount of resources available
+     * @param array $pagination Array of pagination data
      */
     public function __construct(array $resources, $total = null, array $pagination = [])
     {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -31,18 +31,32 @@ class ResultSet implements ResultSetInterface
      */
     protected $_results = [];
 
+    /**
+     * Total number of records
+     * 
+     * @var int
+     */
     protected $_total;
+
+    /**
+     * Array of pagination data
+     * 
+     * @var array
+     */
+    protected $_pagination;
 
     /**
      * Construct the ResultSet
      *
      * @param array $resources The resources to attach
+     * @param array $pagination Array of pagination data
      * @param int|null $total The total amount of resources available
      */
-    public function __construct(array $resources, $total = null)
+    public function __construct(array $resources, $total = null, array $pagination = [])
     {
         $this->_results = \SplFixedArray::fromArray($resources, false);
         $this->_total = $total;
+        $this->_pagination = $pagination;
     }
 
     /**
@@ -127,5 +141,15 @@ class ResultSet implements ResultSetInterface
     public function total()
     {
         return $this->_total;
+    }
+
+    /**
+     * Return the pagination data array
+     * 
+     * @return array
+     */
+    public function pagination()
+    {
+        return $this->_pagination;
     }
 }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -33,14 +33,14 @@ class ResultSet implements ResultSetInterface
 
     /**
      * Total number of records
-     * 
+     *
      * @var int
      */
     protected $_total;
 
     /**
      * Array of pagination data
-     * 
+     *
      * @var array
      */
     protected $_pagination;
@@ -49,8 +49,8 @@ class ResultSet implements ResultSetInterface
      * Construct the ResultSet
      *
      * @param array $resources The resources to attach
-     * @param array $pagination Array of pagination data
-     * @param int|null $total The total amount of resources available
+     * @param array $total Array of pagination data
+     * @param null $pagination The total amount of resources available
      */
     public function __construct(array $resources, $total = null, array $pagination = [])
     {
@@ -145,7 +145,7 @@ class ResultSet implements ResultSetInterface
 
     /**
      * Return the pagination data array
-     * 
+     *
      * @return array
      */
     public function pagination()

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -35,8 +35,8 @@ class ResultSetTest extends TestCase
                     'id' => 3,
                     'title' => 'Webservices'
                 ])
-            ], 
-            6, 
+            ],
+            6,
             ['count' => 6, 'prevPage' => false, 'nextPage' => false]
         );
     }

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -21,20 +21,24 @@ class ResultSetTest extends TestCase
     {
         parent::setUp();
 
-        $this->resultSet = new ResultSet([
-            new Resource([
-                'id' => 1,
-                'title' => 'Hello World'
-            ]),
-            new Resource([
-                'id' => 2,
-                'title' => 'New ORM'
-            ]),
-            new Resource([
-                'id' => 3,
-                'title' => 'Webservices'
-            ])
-        ], 6);
+        $this->resultSet = new ResultSet(
+            [
+                new Resource([
+                    'id' => 1,
+                    'title' => 'Hello World'
+                ]),
+                new Resource([
+                    'id' => 2,
+                    'title' => 'New ORM'
+                ]),
+                new Resource([
+                    'id' => 3,
+                    'title' => 'Webservices'
+                ])
+            ], 
+            6, 
+            ['count' => 6, 'prevPage' => false, 'nextPage' => false]
+        );
     }
 
     public function testCount()
@@ -57,6 +61,11 @@ class ResultSetTest extends TestCase
         $unserialized = unserialize(serialize($this->resultSet));
 
         $this->assertInstanceOf('\Muffin\Webservice\ResultSet', $unserialized);
+    }
+
+    public function testPagination()
+    {
+        $this->assertEquals(['count' => 6, 'prevPage' => false, 'nextPage' => false], $this->resultSet->pagination());
     }
 
     /**


### PR DESCRIPTION
Resolves #42 

When reading apis which are paginated, it's helpful to have a recursive function. However it needs an exit condition, so preserving the pagination data it returns allows for this by keeping the pagination data with the result set.