### PR TITLE
Update Endpoint.php

### DIFF
--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -49,6 +49,13 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
      * @var string
      */
     const VALIDATOR_PROVIDER_NAME = 'endpoint';
+    
+     /**
+     * The name of the event dispatched when a validator has been built.
+     *
+     * @var string
+     */
+    const BUILD_VALIDATOR_EVENT = 'Model.buildValidator';
 
     protected $_connection;
 


### PR DESCRIPTION
As per the ValidatorAwareTrait:

 * This trait expects that classes including it define three constants:
 *
 * - `DEFAULT_VALIDATOR` - The default validator name.
 * - `VALIDATOR_PROVIDER_NAME ` - The provider name the including class is assigned
 *   in validators.
 * - `BUILD_VALIDATOR_EVENT` - The name of the event to be triggred when validators
 *   are built.

Endpoint.php was including this trait and missing the BUILD_VALIDATOR_EVENT const