### PR TITLE
Ensure endpoint is inflected correctly to classname

### DIFF
--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -168,7 +168,8 @@ abstract class Webservice implements WebserviceInterface
         $shortName = App::shortName(get_class($this), 'Webservice', 'Webservice');
         list($plugin, $name) = pluginSplit($shortName);
 
-        $schemaShortName = implode('.', array_filter([$plugin, Inflector::classify($endpoint)]));
+        $endpoint = Inflector::classify(str_replace('-', '_', $endpoint));
+        $schemaShortName = implode('.', array_filter([$plugin, $endpoint]));
         $schemaClassName = App::className($schemaShortName, 'Model/Endpoint/Schema', 'Schema');
         if ($schemaClassName) {
             return new $schemaClassName($endpoint);

--- a/tests/TestCase/Webservice/WebserviceTest.php
+++ b/tests/TestCase/Webservice/WebserviceTest.php
@@ -200,6 +200,15 @@ class WebserviceTest extends TestCase
         $this->assertInstanceOf('\Muffin\Webservice\Model\Resource', $resources[0]);
     }
 
+    public function testDescribe()
+    {
+        $service = new TestWebservice();
+
+        $result = $service->describe('test');
+        $this->assertInstanceOf('\Muffin\Webservice\Model\Schema', $result);
+        $this->assertEquals('Test', $result->name());
+    }
+
     public function testDebugInfo()
     {
         $this->assertEquals([


### PR DESCRIPTION
When using dasherize for endpoint inflections, Cake's inflector for classify does not handle dashes correctly. Calling underscore first, ensures getting correct classname in `describe()`