### PR TITLE
Implement soft required QueryInterface methods

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -262,6 +262,20 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     }
 
     /**
+     * Add AND conditions to the query
+     *
+     * @param array $conditions
+     * @param array $types
+     * @return $this
+     */
+    public function andWhere($conditions, $types = [])
+    {
+        $this->where($conditions, $types);
+
+        return $this;
+    }
+
+    /**
      * Charge this query's action
      *
      * @param int|null $action Action to use
@@ -536,5 +550,31 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     public function jsonSerialize()
     {
         return $this->all();
+    }
+
+    /**
+     * Select the fields to include in the query
+     *
+     * @param array $fields
+     * @param bool $overwrite
+     * @return $this
+     */
+    public function select($fields = [], $overwrite = false)
+    {
+        if (!is_string($fields) && is_callable($fields)) {
+            $fields = $fields($this);
+        }
+
+        if (!is_array($fields)) {
+            $fields = [$fields];
+        }
+
+        if ($overwrite) {
+            $this->_parts['select'] = $fields;
+        } else {
+            $this->_parts['select'] = array_merge($this->_parts['select'], $fields);
+        }
+
+        return $this;
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -264,8 +264,10 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     /**
      * Add AND conditions to the query
      *
-     * @param array $conditions
-     * @param array $types
+     * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The conditions to add with AND.
+     * @param array $types associative array of type names used to bind values to query
+     * @see \Cake\Database\Query::where()
+     * @see \Cake\Database\Type
      * @return $this
      */
     public function andWhere($conditions, $types = [])
@@ -555,8 +557,8 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     /**
      * Select the fields to include in the query
      *
-     * @param array $fields
-     * @param bool $overwrite
+     * @param array|\Cake\Database\ExpressionInterface|string|callable $fields fields to be added to the list.
+     * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
     public function select($fields = [], $overwrite = false)

--- a/src/Query.php
+++ b/src/Query.php
@@ -67,7 +67,8 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     protected $_parts = [
         'order' => [],
         'set' => [],
-        'where' => []
+        'where' => [],
+        'select' => []
     ];
 
     /**

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -358,4 +358,18 @@ class EndpointTest extends TestCase
             $endpoint->schema()
         );
     }
+
+    public function testFindWithSelectAndWhere()
+    {
+        $fields = ['id', 'name', 'avatar', 'biography'];
+        $conditions = ['id' => 1];
+
+        $query = $this->endpoint->find()
+            ->select($fields)
+            ->where($conditions);
+
+        $this->assertInstanceOf('\Muffin\Webservice\Query', $query);
+        $this->assertSame($fields, $query->clause('select'));
+        $this->assertSame($conditions, $query->clause('where'));
+    }
 }


### PR DESCRIPTION
References #51 

The aim of this pull request is to address an issue with implementing the new version of `\Cake\Datasource\QueryInterface` which now has a soft requirement for two new methods `select` and `andWhere`.

I have tried to implement these methods to satisfy the interface, to allow for forwards compatibility with newer versions of the interface.