### PR TITLE
Increase test coverage

### DIFF
--- a/src/Model/EndpointRegistry.php
+++ b/src/Model/EndpointRegistry.php
@@ -55,6 +55,7 @@ class EndpointRegistry
      * @param array $options The options you want to build the endpoint with.
      *
      * @return \Muffin\Webservice\Model\Endpoint
+     * @throws \RuntimeException If the class is already in the registry with configuration
      */
     public static function get($alias, array $options = [])
     {
@@ -100,6 +101,7 @@ class EndpointRegistry
 
         $options['registryAlias'] = $alias;
         self::$_instances[$alias] = self::_create($options);
+        self::$_options[$alias] = $options;
 
         return self::$_instances[$alias];
     }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -155,7 +155,7 @@ class Schema
      * - `comment` The comment for the column.
      *
      * @param string $name The name of the column
-     * @param array $attrs The attributes for the column.
+     * @param array|string $attrs The attributes for the column.
      * @return $this
      */
     public function addColumn($name, $attrs)

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -1,0 +1,289 @@
+<?php
+namespace Muffin\Webservice\Test\TestCase;
+
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Entity;
+use Muffin\Webservice\Connection;
+use Muffin\Webservice\Marshaller;
+use Muffin\Webservice\Model\Resource;
+use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
+
+class MarshallerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Marshaller
+     */
+    private $marshaller;
+
+    /**
+     * Create a marshaller instance for testing
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $connection = new Connection([
+            'name' => 'test',
+            'service' => 'Test'
+        ]);
+        $endpoint = new TestEndpoint([
+            'connection' => $connection,
+            'primaryKey' => 'id',
+            'displayField' => 'title'
+        ]);
+
+        $this->marshaller = new Marshaller($endpoint);
+    }
+
+    public function testOne()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertEquals('Testing one', $result->get('title'));
+        $this->assertEquals('Testing the marshaller', $result->get('body'));
+    }
+
+    public function testOneWithFieldList()
+    {
+        $result = $this->marshaller->one(
+            [
+                'id' => '',
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ],
+            [
+                'fieldList' => ['title']
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertEquals('Testing one', $result->get('title'));
+        $this->assertNull($result->get('body'));
+    }
+
+    public function testOneWithAccessibleFields()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ],
+            [
+                'accessibleFields' => ['body' => false]
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertEquals('Testing one', $result->get('title'));
+        $this->assertNull($result->get('body'));
+    }
+
+    public function testOneWithNoFields()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ],
+            [
+                'fieldList' => [],
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertNull($result->get('title'));
+        $this->assertNull($result->get('body'));
+    }
+
+    public function testOneWithNoAccessible()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ],
+            [
+                'accessibleFields' => ['title' => false, 'body' => false]
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertNull($result->get('title'));
+        $this->assertNull($result->get('body'));
+    }
+
+    /**
+     * If the `fieldList` option is set, it should take precedence over the `accessibleFields` option
+     *
+     * @return void
+     */
+    public function testOneEnsuringFieldListBeforeAccessible()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Testing the marshaller'
+            ],
+            [
+                'fieldList' => ['title', 'body'],
+                'accessibleFields' => ['title' => false, 'body' => false]
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertEquals('Testing one', $result->get('title'));
+        $this->assertEquals('Testing the marshaller', $result->get('body'));
+    }
+
+    public function testOneWithFailedValidation()
+    {
+        $result = $this->marshaller->one(
+            [
+                'title' => 'Testing one',
+                'body' => 'Foo'
+            ]
+        );
+
+        $this->assertInstanceOf(Resource::class, $result);
+        $this->assertEquals('Testing one', $result->get('title'));
+        $this->assertNull($result->get('body'));
+        $this->assertEquals(
+            ['body' => ['minLength' => 'Must be 5 characters or longer']],
+            $result->getErrors()
+        );
+        $this->assertEquals('Foo', $result->getInvalidField('body'));
+    }
+
+    /**
+     * Note that the request data is an array of arrays
+     *
+     * @return void
+     */
+    public function testMany()
+    {
+        $result = $this->marshaller->many([
+            [
+                'title' => 'First',
+                'body' => 'First body'
+            ],
+            [
+                'title' => 'Second',
+                'body' => 'Second body'
+            ],
+            'Non array value'
+        ]);
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey(0, $result);
+        $this->assertInstanceOf(Resource::class, $result[0]);
+        $this->assertEquals('First', $result[0]->get('title'));
+        $this->assertEquals('First body', $result[0]->get('body'));
+
+        $this->assertArrayHasKey(1, $result);
+        $this->assertInstanceOf(Resource::class, $result[1]);
+        $this->assertEquals('Second', $result[1]->get('title'));
+        $this->assertEquals('Second body', $result[1]->get('body'));
+    }
+
+    public function testMerge()
+    {
+        $entity = new Entity([
+            'id' => 1,
+            'title' => 'Testing',
+            'body' => 'The test body'
+        ]);
+
+        $data = [
+            'title' => 'Changed the title',
+            'body' => 'Changed the body'
+        ];
+
+        $result = $this->marshaller->merge($entity, $data);
+
+        $this->assertInstanceOf(EntityInterface::class, $result);
+        $this->assertEquals('Changed the title', $entity->get('title'));
+        $this->assertEquals('Changed the body', $entity->get('body'));
+    }
+
+    public function testMergeWithValidationErrors()
+    {
+        $entity = new Entity([
+            'id' => 1,
+            'title' => 'Testing',
+            'body' => 'Longer body'
+        ]);
+        $entity->isNew(false);
+
+        $data = [
+            'title' => 'Changed the title',
+            'body' => 'Foo'
+        ];
+
+        $result = $this->marshaller->merge($entity, $data);
+
+        $this->assertInstanceOf(EntityInterface::class, $result);
+        $this->assertEquals('Changed the title', $entity->get('title'));
+        $this->assertEquals('Longer body', $entity->get('body'));
+        $this->assertEquals(
+            ['body' => ['minLength' => 'Must be 5 characters or longer']],
+            $result->getErrors()
+        );
+        $this->assertEquals('Foo', $result->getInvalidField('body'));
+    }
+
+    public function testMergeWithOptions()
+    {
+        $entity = new Entity([
+            'id' => 1,
+            'title' => 'Testing',
+            'body' => 'Longer body'
+        ]);
+
+        $data = [
+            'title' => 'Changed the title',
+            'body' => 'Changed the body'
+        ];
+
+        $result = $this->marshaller->merge(
+            $entity,
+            $data,
+            [
+                'fieldList' => ['title'],
+                'accessibleFields' => ['title' => true, 'body' => false],
+                'validate' => false
+            ]
+        );
+
+        $this->assertInstanceOf(EntityInterface::class, $result);
+        $this->assertEquals('Changed the title', $entity->get('title'));
+        $this->assertEquals('Longer body', $entity->get('body'));
+    }
+
+    public function testMergeMany()
+    {
+        $entities = [
+            new Entity(['id' => 1, 'title' => 'First', 'body' => 'First body']),
+            new Entity(['id' => 2, 'title' => 'Second', 'body' => 'Second body']),
+            new Entity(['id' => 3, 'title' => 'Not matching', 'body' => 'An entity which does not match data']),
+        ];
+
+        $data = [
+            ['id' => 1, 'title' => 'Changed first', 'body' => 'First body'],
+            ['id' => 2, 'title' => 'Changed second', 'body' => 'Second body'],
+        ];
+
+        $result = $this->marshaller->mergeMany($entities, $data);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('Changed first', $result[0]->get('title'));
+        $this->assertEquals('Changed second', $result[1]->get('title'));
+    }
+}

--- a/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
+++ b/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @package MuffinWebservice
+ * @author David Yell <dyell@ukwebmedia.com>
+ * @copyright UK Web Media Ltd
+ */
+
+namespace Muffin\Webservice\Test\TestCase\Model\Endpoint\Schema;
+
+use Muffin\Webservice\Test\test_app\Model\Endpoint\Schema\TestSchema;
+use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
+
+class SchemaTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Muffin\Webservice\Schema
+     */
+    private $schema;
+
+    protected function setUp()
+    {
+        $this->schema = new TestSchema(new TestEndpoint());
+    }
+
+    public function testName()
+    {
+        $this->assertEquals($this->schema->name()->getName(), 'test');
+    }
+
+    public function testAddColumn()
+    {
+        $updatedSchema = $this->schema->addColumn('example', ['type' => 'string']);
+        $this->assertContains('example', $updatedSchema->columns());
+    }
+
+    public function testAddColumnWithStringAttributes()
+    {
+        $updatedSchema = $this->schema->addColumn('example', 'string');
+        $this->assertContains('example', $updatedSchema->columns());
+    }
+
+    public function testColumns()
+    {
+        $this->assertEquals(['id', 'title', 'body'], $this->schema->columns());
+    }
+
+    public function testColumn()
+    {
+        $this->assertEquals(
+            [
+                'type' => 'int',
+                'length' => null,
+                'precision' => null,
+                'null' => null,
+                'default' => null,
+                'comment' => null,
+                'primaryKey' => null
+            ],
+            $this->schema->column('id')
+        );
+    }
+
+    public function testColumnType()
+    {
+
+    }
+
+    public function testBaseColumnType()
+    {
+
+    }
+
+    public function testTypeMap()
+    {
+
+    }
+
+    public function testIsNullable()
+    {
+
+    }
+
+    public function testDefaultValues()
+    {
+
+    }
+
+    public function testPrimaryKey()
+    {
+
+    }
+
+    public function testOptions()
+    {
+
+    }
+}

--- a/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
+++ b/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
@@ -8,7 +8,6 @@
 namespace Muffin\Webservice\Test\TestCase\Model\Endpoint\Schema;
 
 use Muffin\Webservice\Test\test_app\Model\Endpoint\Schema\TestSchema;
-use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
 
 class SchemaTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,12 +18,12 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->schema = new TestSchema(new TestEndpoint());
+        $this->schema = new TestSchema('test');
     }
 
     public function testName()
     {
-        $this->assertEquals($this->schema->name()->getName(), 'test');
+        $this->assertEquals($this->schema->name(), 'test');
     }
 
     public function testAddColumn()
@@ -62,36 +61,81 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
     public function testColumnType()
     {
+        $this->assertEquals('int', $this->schema->columnType('id'));
+    }
 
+    public function testMissingColumnType()
+    {
+        $this->assertNull($this->schema->columnType('missing'));
+    }
+
+    public function testChangingColumnType()
+    {
+        $this->assertEquals('string', $this->schema->columnType('body'));
+        $this->schema->columnType('body', 'text');
+        $this->assertEquals('text', $this->schema->columnType('body'));
     }
 
     public function testBaseColumnType()
     {
+        $this->schema->addColumn('example', ['type' => 'text', 'baseType' => 'string']);
 
+        $this->assertEquals('int', $this->schema->baseColumnType('id'));
+        $this->assertEquals('string', $this->schema->baseColumnType('example'));
+    }
+
+    public function testBaseColumnTypeWithNullType()
+    {
+        $this->schema->addColumn('example', ['type' => null]);
+        $this->assertNull($this->schema->baseColumnType('examples'));
+    }
+
+    public function testBaseColumnTypeFromTypeMap()
+    {
+        $this->schema->addColumn('example', 'text');
+        $this->assertEquals('text', $this->schema->baseColumnType('example'));
     }
 
     public function testTypeMap()
     {
-
+        $this->assertEquals(
+            ['id' => 'int', 'title' => 'string', 'body' => 'string'],
+            $this->schema->typeMap()
+        );
     }
 
     public function testIsNullable()
     {
+        $this->schema->addColumn('nullable_column', ['type' => 'tinyint', 'null' => true]);
+        $this->schema->addColumn('not_nullable_column', ['type' => 'tinyint', 'null' => false]);
 
+        $this->assertTrue($this->schema->isNullable('nullable_column'));
+        $this->assertFalse($this->schema->isNullable('not_nullable_column'));
+    }
+
+    public function testIsNullableWithMissingColumn()
+    {
+        $this->assertTrue($this->schema->isNullable('missing'));
     }
 
     public function testDefaultValues()
     {
+        $this->assertEquals([], $this->schema->defaultValues());
 
+        $this->schema->addColumn('example', ['type' => 'string', 'default' => 'test']);
+        $this->assertEquals(['example' => 'test'], $this->schema->defaultValues());
     }
 
     public function testPrimaryKey()
     {
-
+        $this->schema->addColumn('id', ['type' => 'integer', 'primaryKey' => true]);
+        $this->assertEquals(['id'], $this->schema->primaryKey());
     }
 
     public function testOptions()
     {
-
+        $this->assertEmpty($this->schema->options());
+        $this->schema->options(['example' => true]);
+        $this->assertEquals(['example' => true], $this->schema->options());
     }
 }

--- a/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
+++ b/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * @package MuffinWebservice
- * @author David Yell <dyell@ukwebmedia.com>
- * @copyright UK Web Media Ltd
- */
-
 namespace Muffin\Webservice\Test\TestCase\Model\Endpoint\Schema;
 
 use Muffin\Webservice\Test\test_app\Model\Endpoint\Schema\TestSchema;

--- a/tests/TestCase/Model/EndpointRegistryTest.php
+++ b/tests/TestCase/Model/EndpointRegistryTest.php
@@ -2,6 +2,7 @@
 
 namespace Muffin\Webservice\Model;
 
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Connection;
 use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
@@ -86,26 +87,6 @@ class EndpointRegistryTest extends TestCase
 
         $this->assertInstanceOf(Endpoint::class, $result);
         $this->assertEquals('unfindable_class', $result->endpoint());
-    }
-
-    public function testGetInstanceWithNoConnectionAndClassName()
-    {
-        $result = EndpointRegistry::get('Test', [
-            'className' => TestEndpoint::class
-        ]);
-
-        $this->assertInstanceOf(Endpoint::class, $result);
-        $this->assertEquals('test', $result->endpoint());
-    }
-
-    public function testGetInstanceWithNoConnectionAndNoClassName()
-    {
-        $result = EndpointRegistry::get('SomeVendor/SomePlugin.Plugin', [
-            'className' => 'Muffin\Webservice\Model\Endpoint'
-        ]);
-
-        $this->assertInstanceOf(Endpoint::class, $result);
-        $this->assertEquals('test', $result->endpoint());
     }
 
     public function testRemovingInstance()

--- a/tests/TestCase/Model/EndpointRegistryTest.php
+++ b/tests/TestCase/Model/EndpointRegistryTest.php
@@ -4,6 +4,7 @@ namespace Muffin\Webservice\Model;
 
 use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Connection;
+use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
 
 class EndpointRegistryTest extends TestCase
 {
@@ -26,7 +27,8 @@ class EndpointRegistryTest extends TestCase
             ])
         ]);
 
-        $this->assertInstanceOf(\Muffin\Webservice\Model\Endpoint::class, $result);
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
     }
 
     /**
@@ -34,24 +36,76 @@ class EndpointRegistryTest extends TestCase
      * exception is thrown
      *
      * @expectedException \RuntimeException
+     * @expectedExceptionMessage You cannot configure "Test", it already exists in the registry.
      */
-    public function testAddingSameEndpoint()
+    public function testReconfiguringExistingInstance()
     {
         $result = EndpointRegistry::get('Test', [
             'connection' => new Connection([
                 'name' => 'test',
                 'service' => 'test'
-            ])
+            ]),
+            'displayField' => 'foo'
         ]);
 
-        $this->assertInstanceOf(\Muffin\Webservice\Model\Endpoint::class, $result);
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
 
         $result = EndpointRegistry::get('Test', [
-            'connection' => new Connection([
-                'name' => 'exception',
-                'service' => 'exception'
-            ])
+            'displayField' => 'foo'
         ]);
+    }
+
+    public function testGettingSameInstance()
+    {
+        $result = EndpointRegistry::get('Test', [
+            'connection' => new Connection([
+                'name' => 'test',
+                'service' => 'test'
+            ]),
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
+
+        $result = EndpointRegistry::get('Test');
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
+    }
+
+    public function testGetInstanceWithNoEndpointName()
+    {
+        $result = EndpointRegistry::get('Test', [
+            'connection' => new Connection([
+                'name' => 'test',
+                'service' => 'test'
+            ]),
+            'className' => 'UnfindableClass'
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('unfindable_class', $result->endpoint());
+    }
+
+    public function testGetInstanceWithNoConnectionAndClassName()
+    {
+        $result = EndpointRegistry::get('Test', [
+            'className' => TestEndpoint::class
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
+    }
+
+    public function testGetInstanceWithNoConnectionAndNoClassName()
+    {
+        $result = EndpointRegistry::get('SomeVendor/SomePlugin.Plugin', [
+            'className' => 'Muffin\Webservice\Model\Endpoint'
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('test', $result->endpoint());
     }
 
     public function testRemovingInstance()
@@ -63,7 +117,7 @@ class EndpointRegistryTest extends TestCase
             ])
         ]);
 
-        $this->assertInstanceOf(\Muffin\Webservice\Model\Endpoint::class, $result);
+        $this->assertInstanceOf(Endpoint::class, $result);
 
         EndpointRegistry::remove('Test');
 
@@ -81,7 +135,7 @@ class EndpointRegistryTest extends TestCase
             ])
         ]);
 
-        $this->assertInstanceOf(\Muffin\Webservice\Model\Endpoint::class, $result);
+        $this->assertInstanceOf(Endpoint::class, $result);
 
         EndpointRegistry::clear();
 

--- a/tests/test_app/Model/Endpoint/TestEndpoint.php
+++ b/tests/test_app/Model/Endpoint/TestEndpoint.php
@@ -22,7 +22,8 @@ class TestEndpoint extends Endpoint
         $validator->requirePresence('title')
             ->notEmpty('title')
             ->requirePresence('body')
-            ->notEmpty('body');
+            ->notEmpty('body')
+            ->minLength('body', 5, 'Must be 5 characters or longer');
 
         return $validator;
     }


### PR DESCRIPTION
References #51 

The aim of this pull request is to increase the test coverage across the plugin, to aid in the refactoring required for the `2.0.0` release.

I have added a number of test cases for classes which were missing coverage. The main indicator used to develop the tests was generating coverage with phpunit, so some code paths may still be missing from the test suite.

The `AbstractDriver` class has low test coverage due to its test suite being in #57 so once that is merged coverage should increase again.

I have added a new validation rule to the `TestEndpoint` in order to be able to test against `invalidField()` which returns the invalid value.