### PR TITLE
Replace @inheritDoc

### DIFF
--- a/src/Exception/MissingConnectionException.php
+++ b/src/Exception/MissingConnectionException.php
@@ -7,7 +7,9 @@ class MissingConnectionException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'No `%` connection configured.';
 }

--- a/src/Exception/MissingDriverException.php
+++ b/src/Exception/MissingDriverException.php
@@ -7,7 +7,9 @@ class MissingDriverException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'Webservice driver %s could not be found.';
 }

--- a/src/Exception/MissingEndpointSchemaException.php
+++ b/src/Exception/MissingEndpointSchemaException.php
@@ -8,7 +8,9 @@ class MissingEndpointSchemaException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'Missing schema %s or webservice %s describe implementation';
 }

--- a/src/Exception/UnexpectedDriverException.php
+++ b/src/Exception/UnexpectedDriverException.php
@@ -7,7 +7,9 @@ class UnexpectedDriverException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'Driver (`%s`) should extend `Muffin\Webservice\AbstractDriver`';
 }

--- a/src/Exception/UnimplementedDriverMethodException.php
+++ b/src/Exception/UnimplementedDriverMethodException.php
@@ -7,7 +7,9 @@ class UnimplementedDriverMethodException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'Driver (`%s`) does not implement `%s`';
 }

--- a/src/Exception/UnimplementedWebserviceMethodException.php
+++ b/src/Exception/UnimplementedWebserviceMethodException.php
@@ -7,7 +7,9 @@ class UnimplementedWebserviceMethodException extends Exception
 {
 
     /**
-     * {@inheritDoc}
+     * Template string that has attributes sprintf()'ed into it.
+     *
+     * @var string
      */
     protected $_messageTemplate = 'Webservice %s does not implement %s';
 }

--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -1046,8 +1046,16 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
     }
 
     /**
-     * {@inheritDoc}
+     * Create a new entity + associated entities from an array.
      *
+     * This is most useful when hydrating web service data back into entities.
+     *
+     * The hydrated entity will correctly do an insert/update based
+     * on the primary key data existing in the database when the entity
+     * is saved. Until the entity is saved, it will be a detached record.
+     *
+     * @param array|null $data The data to build an entity with.
+     * @param array $options A list of options for the object hydration.
      * @return \Muffin\Webservice\Model\Resource
      */
     public function newEntity($data = null, array $options = [])
@@ -1175,7 +1183,10 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
     }
 
     /**
-     * {@inheritDoc}
+     * Returns a RulesChecker object after modifying the one that was supplied.
+     *
+     * Subclasses should override this method in order to initialize the rules to be applied to
+     * entities saved by this instance.
      *
      * @param \Cake\Datasource\RulesChecker $rules The rules object to be modified.
      * @return \Cake\Datasource\RulesChecker

--- a/src/Query.php
+++ b/src/Query.php
@@ -203,7 +203,20 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Apply custom finds to against an existing query object.
+     *
+     * Allows custom find methods to be combined and applied to each other.
+     *
+     * ```
+     * $repository->find('all')->find('recent');
+     * ```
+     *
+     * The above is an example of stacking multiple finder methods onto
+     * a single query.
+     *
+     * @param string $finder The finder method to use.
+     * @param array $options The options for the finder.
+     * @return $this Returns a modified query.
      */
     public function find($finder, array $options = [])
     {
@@ -385,7 +398,21 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Adds a single or multiple fields to be used in the ORDER clause for this query.
+     * Fields can be passed as an array of strings, array of expression
+     * objects, a single expression or a single string.
+     *
+     * If an array is passed, keys will be used as the field itself and the value will
+     * represent the order in which such field should be ordered. When called multiple
+     * times with the same fields as key, the last order definition will prevail over
+     * the others.
+     *
+     * By default this function will append any passed argument to the list of fields
+     * to be selected, unless the second argument is set to true.
+     *
+     * @param array|string $fields fields to be added to the list
+     * @param bool $overwrite whether to reset order with field list or not
+     * @return $this
      */
     public function order($fields, $overwrite = false)
     {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -46,7 +46,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the current record in the result iterator
+     *
+     * Part of Iterator interface.
+     *
+     * @return array|object
      */
     public function current()
     {
@@ -54,7 +58,12 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Rewinds a ResultSet.
+     *
+     * Part of Iterator interface.
+     *
+     * @throws \Cake\Database\Exception
+     * @return void
      */
     public function rewind()
     {
@@ -62,7 +71,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Serializes a resultset.
+     *
+     * Part of Serializable interface.
+     *
+     * @return string Serialized object
      */
     public function serialize()
     {
@@ -74,7 +87,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Whether there are more results to be fetched from the iterator
+     *
+     * Part of Iterator interface.
+     *
+     * @return bool
      */
     public function valid()
     {
@@ -88,7 +105,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the key of the current record in the iterator
+     *
+     * Part of Iterator interface.
+     *
+     * @return int
      */
     public function key()
     {
@@ -96,7 +117,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Advances the iterator pointer to the next record
+     *
+     * Part of Iterator interface.
+     *
+     * @return void
      */
     public function next()
     {
@@ -104,7 +129,12 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Unserializes a resultset.
+     *
+     * Part of Serializable interface.
+     *
+     * @param string $serialized Serialized object
+     * @return void
      */
     public function unserialize($serialized)
     {
@@ -112,7 +142,11 @@ class ResultSet implements ResultSetInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Gives the number of rows in the result set.
+     *
+     * Part of the Countable interface.
+     *
+     * @return int
      */
     public function count()
     {

--- a/src/Routing/Filter/ControllerEndpointFilter.php
+++ b/src/Routing/Filter/ControllerEndpointFilter.php
@@ -21,10 +21,19 @@ class ControllerEndpointFilter extends DispatcherFilter
     protected $_priority = 51;
 
     /**
-     * @inheritDoc
+     * Method called before the controller is instantiated and called to serve a request.
+     * If used with default priority, it will be called after the Router has parsed the
+     * URL and set the routing params into the request object.
      *
-     * @param \Cake\Event\Event $event The event to handle
+     * If a Cake\Http\Response object instance is returned, it will be served at the end of the
+     * event cycle, not calling any controller as a result. This will also have the effect of
+     * not calling the after event in the dispatcher.
      *
+     * If false is returned, the event will be stopped and no more listeners will be notified.
+     * Alternatively you can call `$event->stopPropagation()` to achieve the same result.
+     *
+     * @param \Cake\Event\Event $event container object having the `request`, `response` and `additionalParams`
+     *    keys in the data property.
      * @return void
      */
     public function beforeDispatch(Event $event)

--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -142,7 +142,12 @@ abstract class Webservice implements WebserviceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Executes a query
+     *
+     * @param Query $query The query to execute
+     * @param array $options The options to use
+     *
+     * @return \Muffin\Webservice\ResultSet|int|bool
      */
     public function execute(Query $query, array $options = [])
     {
@@ -161,7 +166,10 @@ abstract class Webservice implements WebserviceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns a schema for the provided endpoint
+     *
+     * @param string $endpoint The endpoint to get the schema for
+     * @return \Muffin\Webservice\Schema The schema to use
      */
     public function describe($endpoint)
     {


### PR DESCRIPTION
References #51 

The aim of this pull request is to replace the use of `{@inheritDoc}` within the codebase, as it doesn't really do anything and obfuscates the explanatory usage notes of the methods.

I have copied the doc blocks from the parent classes.