### PR TITLE
Bump to CakePHP-Codesniffer 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "cakephp/cakephp": "dev-3.next as 3.6.0"        
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "2.*",
+        "cakephp/cakephp-codesniffer": "3.*",
         "phpunit/phpunit": "<6.0"
     },
     "autoload": {

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -268,7 +268,7 @@ class QueryTest extends TestCase
         $exp = new Comparison('upvotes', 50, 'integer', '>=');
         $this->query->select($exp);
 
-    /** @var Comparison $comparisonClause */
+        /** @var Comparison $comparisonClause */
         $comparisonClause = $this->query->clause('select')[0];
 
         $this->assertInstanceOf(Comparison::class, $comparisonClause);


### PR DESCRIPTION
References #51 

This pull request bumps the version of the code sniffer up to the next major release. I've also fixed the single warning which was generated.