### PR TITLE
Refactored mixed mode methods in Schema

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -208,6 +208,7 @@ class Schema
      * @param string $name The column to get the type of.
      * @param string $type The type to set the column to.
      * @return string|null Either the column type or null.
+     * @deprecated Since 2.0.0 please use setColumnType or getColumnType instead.
      */
     public function columnType($name, $type = null)
     {
@@ -215,8 +216,37 @@ class Schema
             return null;
         }
         if ($type !== null) {
-            $this->_columns[$name]['type'] = $type;
-            $this->_typeMap[$name] = $type;
+            $this->setColumnType($name, $type);
+        }
+
+        return $this->getColumnType($name);
+    }
+
+    /**
+     * Set the type of a column
+     *
+     * @param string $name Column name
+     * @param string $type Type to set for the column
+     * @return $this
+     */
+    public function setColumnType($name, $type)
+    {
+        $this->_columns[$name]['type'] = $type;
+        $this->_typeMap[$name] = $type;
+
+        return $this;
+    }
+
+    /**
+     * Get the type of a column
+     *
+     * @param string $name Column name
+     * @return null|string
+     */
+    public function getColumnType($name)
+    {
+        if (!isset($this->_columns[$name])) {
+            return null;
         }
 
         return $this->_columns[$name]['type'];
@@ -236,7 +266,7 @@ class Schema
             return $this->_columns[$column]['baseType'];
         }
 
-        $type = $this->columnType($column);
+        $type = $this->getColumnType($column);
 
         if ($type === null) {
             return null;
@@ -325,14 +355,39 @@ class Schema
      *
      * @param array|null $options The options to set, or null to read options.
      * @return $this|array Either the endpoint instance, or an array of options when reading.
+     * @deprecated Since 2.0.0 please use setOptions and getOptions instead.
      */
     public function options($options = null)
     {
         if ($options === null) {
-            return $this->_options;
+            return $this->getOptions();
         }
+
+        $this->setOptions($options);
+
+        return $this;
+    }
+
+    /**
+     * Set the schema options for an endpoint
+     *
+     * @param array $options Array of options to set
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
         $this->_options = array_merge($this->_options, $options);
 
         return $this;
+    }
+
+    /**
+     * Get the schema options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->_options;
     }
 }

--- a/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
+++ b/tests/TestCase/Model/Endpoint/Schema/SchemaTest.php
@@ -55,19 +55,19 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
     public function testColumnType()
     {
-        $this->assertEquals('int', $this->schema->columnType('id'));
+        $this->assertEquals('int', $this->schema->getColumnType('id'));
     }
 
     public function testMissingColumnType()
     {
-        $this->assertNull($this->schema->columnType('missing'));
+        $this->assertNull($this->schema->getColumnType('missing'));
     }
 
     public function testChangingColumnType()
     {
-        $this->assertEquals('string', $this->schema->columnType('body'));
-        $this->schema->columnType('body', 'text');
-        $this->assertEquals('text', $this->schema->columnType('body'));
+        $this->assertEquals('string', $this->schema->getColumnType('body'));
+        $this->schema->setColumnType('body', 'text');
+        $this->assertEquals('text', $this->schema->getColumnType('body'));
     }
 
     public function testBaseColumnType()
@@ -128,8 +128,8 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
     public function testOptions()
     {
-        $this->assertEmpty($this->schema->options());
-        $this->schema->options(['example' => true]);
-        $this->assertEquals(['example' => true], $this->schema->options());
+        $this->assertEmpty($this->schema->getOptions());
+        $this->schema->setOptions(['example' => true]);
+        $this->assertEquals(['example' => true], $this->schema->getOptions());
     }
 }


### PR DESCRIPTION
References #51 

The aim of this pull request is to continue work on refactoring the mixed mode methods found in the plugin. These methods in the Schema class were missed in #57 so this addresses that omission.

I have updated the tests to use the new methods, rather than adding new test cases, because testing the new api is more important than testing deprecated methods.