### PR TITLE
Deprecate the DispatchFilter

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,3 +1,2 @@
 <?php
-
-\Cake\Routing\DispatcherFactory::add('Muffin/Webservice.ControllerEndpoint');
+\Cake\Datasource\FactoryLocator::add('Endpoint', [Muffin\Webservice\Model\EndpointRegistry::class, 'get']);

--- a/src/Routing/Filter/ControllerEndpointFilter.php
+++ b/src/Routing/Filter/ControllerEndpointFilter.php
@@ -9,6 +9,7 @@ use Cake\Routing\DispatcherFilter;
  * This filter registers the endpoint model type in controllers
  *
  * @package Muffin\Webservice\Routing\Filter
+ * @deprecated Since 2.0.0
  */
 class ControllerEndpointFilter extends DispatcherFilter
 {

--- a/src/Routing/Filter/ControllerEndpointFilter.php
+++ b/src/Routing/Filter/ControllerEndpointFilter.php
@@ -9,7 +9,7 @@ use Cake\Routing\DispatcherFilter;
  * This filter registers the endpoint model type in controllers
  *
  * @package Muffin\Webservice\Routing\Filter
- * @deprecated Since 2.0.0
+ * @deprecated 2.0.0 Dispatch filters are deprecated
  */
 class ControllerEndpointFilter extends DispatcherFilter
 {

--- a/tests/TestCase/BootstrapTest.php
+++ b/tests/TestCase/BootstrapTest.php
@@ -10,11 +10,6 @@ use Cake\TestSuite\TestCase;
 use Muffin\Webservice\Connection;
 use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
 
-/**
- * @package MuffinWebservice
- * @author David Yell <dyell@ukwebmedia.com>
- * @copyright UK Web Media Ltd
- */
 class BootstrapTest extends TestCase
 {
     /**

--- a/tests/TestCase/BootstrapTest.php
+++ b/tests/TestCase/BootstrapTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Muffin\Webservice\Test\TestCase;
+
+use Cake\Controller\Controller;
+use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\FactoryLocator;
+use Cake\TestSuite\TestCase;
+use Muffin\Webservice\Connection;
+use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
+
+/**
+ * @package MuffinWebservice
+ * @author David Yell <dyell@ukwebmedia.com>
+ * @copyright UK Web Media Ltd
+ */
+class BootstrapTest extends TestCase
+{
+    /**
+     * Test that the plugins bootstrap is correctly registering the Endpoint
+     * repository type with the factory locator
+     *
+     * @return void
+     */
+    public function testLoadingEndpointWithLoadModel()
+    {
+        Plugin::load('Muffin/Webservice', [
+            'path' => ROOT . 'src',
+            'bootstrap' => true
+        ]);
+
+        $connection = new Connection([
+            'name' => 'test',
+            'service' => 'Test'
+        ]);
+        ConnectionManager::setConfig('test_app', $connection);
+
+        $controller = new Controller();
+        $endpoint = $controller->loadModel('Test', 'Endpoint');
+
+        $this->assertInstanceOf(TestEndpoint::class, $endpoint);
+        $this->assertEquals('Test', $endpoint->getAlias());
+    }
+
+    public function testFactoryLocatorAddition()
+    {
+        $expected = [\Muffin\Webservice\Model\EndpointRegistry::class, 'get'];
+        $result = FactoryLocator::get('Endpoint');
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/tests/TestCase/Model/EndpointRegistryTest.php
+++ b/tests/TestCase/Model/EndpointRegistryTest.php
@@ -9,7 +9,7 @@ use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
 
 class EndpointRegistryTest extends TestCase
 {
-    public function tearDown()
+    public function setUp()
     {
         EndpointRegistry::clear();
     }


### PR DESCRIPTION
References #51 

The aim of this pull request is to address the use of a Dispatch Filter, as they have been deprecated by the core since 3.3.0. [Book page for Dispatch filters](https://book.cakephp.org/3.0/en/development/dispatch-filters.html).

The book says to implement a middleware instead, however, there is no controller instance in the request to modify. Looking at the core plugin for Elastic Search, [they add directly to the Factory in the boostrap](https://github.com/cakephp/elastic-search/blob/master/config/bootstrap.php#L22-L23). 

I have use the same approach for this pull request, by deprecating the class and calling the Factory locator directly to add the Endpoint factory.