### PR TITLE
Remove the use of deprecated dispatcher factory

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -272,7 +272,7 @@ class Schema
             return null;
         }
 
-        if (Type::map($type)) {
+        if (Type::getMap($type)) {
             $type = Type::build($type)->getBaseType();
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,8 +14,8 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\FactoryLocator;
 use Cake\Log\Log;
-use Cake\Routing\DispatcherFactory;
 
 require_once 'vendor/autoload.php';
 
@@ -114,8 +114,5 @@ Log::setConfig([
 ]);
 
 Plugin::load('DebugKit', ['path' => ROOT, 'bootstrap' => true]);
-
-DispatcherFactory::add('Routing');
-DispatcherFactory::add('ControllerFactory');
 
 loadPHPUnitAliases();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,6 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\FactoryLocator;
 use Cake\Log\Log;
 
 require_once 'vendor/autoload.php';


### PR DESCRIPTION
References #51 

The aim of this pull request is to remove the usage of the deprecated Dispatcher Factory called in the Test bootstrap.

I have removed the lines and the test suite still passes. I believe this is because the plugin tests instantiate the classes directly, and so do not rely on the locator class. The `BootstrapTest` class does load the plugin, using it's own bootstrap file. So the class isn't required in the test suites bootstrap.