### PR TITLE
Deprecate the EndpointRegistry

### DIFF
--- a/src/Model/EndpointLocator.php
+++ b/src/Model/EndpointLocator.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Muffin\Webservice\Model;
+
+use Cake\Core\App;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Inflector;
+use RuntimeException;
+
+/**
+ * Class EndpointLocator
+ *
+ * Should implement the LocatorInterface
+ * @see https://github.com/cakephp/cakephp/issues/12014
+ */
+class EndpointLocator
+{
+    /**
+     * Configuration for aliases.
+     *
+     * @var array
+     */
+    protected $_config = [];
+
+    /**
+     * Instances that belong to the registry.
+     *
+     * @var \Muffin\Webservice\Model\Endpoint[]
+     */
+    protected $_instances = [];
+
+    /**
+     * Contains a list of options that were passed to get() method.
+     *
+     * @var array
+     */
+    protected $_options = [];
+
+    /**
+     * Set an Endpoint instance to the registry
+     *
+     * @param string $alias The alias to set.
+     * @param \Muffin\Webservice\Model\Endpoint $object The table to set.
+     * @return \Muffin\Webservice\Model\Endpoint
+     */
+    public function set($alias, Endpoint $object)
+    {
+        return $this->_instances[$alias] = $object;
+    }
+
+    /**
+     * Get a endpoint instance from the registry.
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the endpoint with.
+     * @return \Muffin\Webservice\Model\Endpoint
+     * @throws \RuntimeException If the registry alias is already in use.
+     */
+    public function get($alias, array $options = [])
+    {
+        if (isset($this->_instances[$alias])) {
+            if (!empty($options) && $this->_options[$alias] !== $options) {
+                throw new RuntimeException(sprintf(
+                    'You cannot configure "%s", it already exists in the registry.',
+                    $alias
+                ));
+            }
+
+            return $this->_instances[$alias];
+        }
+
+        list(, $classAlias) = pluginSplit($alias);
+        $options = ['alias' => $classAlias] + $options;
+
+        if (empty($options['className'])) {
+            $options['className'] = Inflector::camelize($alias);
+        }
+        $className = App::className($options['className'], 'Model/Endpoint', 'Endpoint');
+        if ($className) {
+            $options['className'] = $className;
+        } else {
+            if (!isset($options['endpoint']) && strpos($options['className'], '\\') === false) {
+                list(, $endpoint) = pluginSplit($options['className']);
+                $options['endpoint'] = Inflector::underscore($endpoint);
+            }
+            $options['className'] = 'Muffin\Webservice\Model\Endpoint';
+        }
+
+        if (empty($options['connection'])) {
+            if ($options['className'] !== 'Muffin\Webservice\Model\Endpoint') {
+                $connectionName = $options['className']::defaultConnectionName();
+            } else {
+                $pluginParts = explode('/', pluginSplit($alias)[0]);
+
+                $connectionName = Inflector::underscore(end($pluginParts));
+            }
+
+            $options['connection'] = ConnectionManager::get($connectionName);
+        }
+
+        $options['registryAlias'] = $alias;
+        $this->_instances[$alias] = $this->_create($options);
+        $this->_options[$alias] = $options;
+
+        return $this->_instances[$alias];
+    }
+
+    /**
+     * Check to see if an instance exists in the registry.
+     *
+     * @param string $alias The alias to check for.
+     * @return bool
+     */
+    public function exists($alias)
+    {
+        return isset($this->_instances[$alias]);
+    }
+
+    /**
+     * Returns configuration for an alias or the full configuration array for all aliases.
+     *
+     * @param string|null $alias Endpoint alias
+     * @return array
+     */
+    public function getConfig($alias = null)
+    {
+        if ($alias === null) {
+            return $this->_config;
+        }
+
+        return isset($this->_config[$alias]) ? $this->_config[$alias] : [];
+    }
+
+    /**
+     * Stores a list of options to be used when instantiating an object with a matching alias.
+     *
+     * @param string $alias The alias to set configuration for
+     * @param null|array $options Array of options
+     * @return $this
+     * @throws \RuntimeException
+     */
+    public function setConfig($alias, $options = null)
+    {
+        if (!is_string($alias)) {
+            $this->_config = $alias;
+
+            return $this;
+        }
+
+        if (isset($this->_instances[$alias])) {
+            throw new RuntimeException(sprintf(
+                'You cannot configure "%s", it has already been constructed.',
+                $alias
+            ));
+        }
+
+        $this->_config[$alias] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Clear the endpoint locator registry of all instances
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->_instances = [];
+        $this->_options = [];
+        $this->_config = [];
+    }
+
+    /**
+     * Remove a specific endpoint instance from the registry by alias
+     *
+     * @param string $alias String alias of the endpoint
+     * @return void
+     */
+    public function remove($alias)
+    {
+        unset(
+            $this->_instances[$alias],
+            $this->_options[$alias],
+            $this->_config[$alias]
+        );
+    }
+
+    /**
+     * Wrapper for creating endpoint instances
+     *
+     * @param array $options The alias to check for.
+     * @return \Muffin\Webservice\Model\Endpoint
+     */
+    protected function _create(array $options)
+    {
+        return new $options['className']($options);
+    }
+}

--- a/src/Model/EndpointLocator.php
+++ b/src/Model/EndpointLocator.php
@@ -134,12 +134,21 @@ class EndpointLocator
     /**
      * Stores a list of options to be used when instantiating an object with a matching alias.
      *
-     * @param string $alias The alias to set configuration for
-     * @param null|array $options Array of options
+     * If configuring many aliases, use an array keyed by the alias.
+     *
+     * ```
+     * $locator->setConfig([
+     *     'Example' => ['registryAlias' => 'example'],
+     *     'Posts' => ['registryAlias' => 'posts'],
+     * ]);
+     * ```
+     *
+     * @param string|array $alias The alias to set configuration for, or an array of configuration keyed by alias
+     * @param null|array $config Array of configuration options
      * @return $this
      * @throws \RuntimeException
      */
-    public function setConfig($alias, $options = null)
+    public function setConfig($alias, $config = null)
     {
         if (!is_string($alias)) {
             $this->_config = $alias;
@@ -154,7 +163,7 @@ class EndpointLocator
             ));
         }
 
-        $this->_config[$alias] = $options;
+        $this->_config[$alias] = $config;
 
         return $this;
     }

--- a/src/Model/EndpointLocator.php
+++ b/src/Model/EndpointLocator.php
@@ -11,6 +11,7 @@ use RuntimeException;
  * Class EndpointLocator
  *
  * Should implement the LocatorInterface
+ * @see \Cake\ORM\Locator\LocatorInterface
  * @see https://github.com/cakephp/cakephp/issues/12014
  */
 class EndpointLocator

--- a/src/Model/EndpointRegistry.php
+++ b/src/Model/EndpointRegistry.php
@@ -8,6 +8,11 @@ use Cake\Utility\Inflector;
 use Muffin\Webservice\AbstractDriver;
 use RuntimeException;
 
+/**
+ * EndpointRegistry
+ *
+ * @deprecated 2.0.0 The registry has been deprecated, please use EndpointLocator instead.
+ */
 class EndpointRegistry
 {
 

--- a/tests/TestCase/Model/EndpointLocatorTest.php
+++ b/tests/TestCase/Model/EndpointLocatorTest.php
@@ -1,0 +1,171 @@
+<?php
+namespace Muffin\Webservice\Model;
+
+use Cake\TestSuite\TestCase;
+
+class EndpointLocatorTest extends TestCase
+{
+    /**
+     * @var \Muffin\Webservice\Model\EndpointLocator
+     */
+    private $Locator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Locator = new EndpointLocator();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($this->Locator);
+    }
+
+    public function testConfig()
+    {
+        $this->assertSame([], $this->Locator->getConfig());
+
+        $configTest = ['foo' => 'bar'];
+        $this->Locator->setConfig('test', $configTest);
+        $this->assertSame($configTest, $this->Locator->getConfig('test'));
+
+        $configExample = ['example' => true];
+        $this->Locator->setConfig('example', $configExample);
+        $this->assertSame($configExample, $this->Locator->getConfig('example'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage You cannot configure "Test", it has already been constructed.
+     */
+    public function testSetConfigForExistingObject()
+    {
+        $this->Locator->get('Test', [
+            'registryAlias' => 'Test',
+            'connection' => 'test'
+        ]);
+
+        $this->Locator->setConfig('Test', ['foo' => 'bar']);
+    }
+
+    public function testSetConfigUsingAliasArray()
+    {
+        $multiAliasConfig = [
+            'Test' => ['foo' => 'bar'],
+            'Example' => ['foo' => 'bar']
+        ];
+
+        $result = $this->Locator->setConfig($multiAliasConfig);
+        $this->assertInstanceOf(EndpointLocator::class, $result);
+
+        $this->assertSame($multiAliasConfig, $this->Locator->getConfig());
+    }
+
+    public function testRemoveUsingExists()
+    {
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Muffin\Webservice\Model\Endpoint $first */
+        $first = $this->getMockBuilder(Endpoint::class)
+            ->setConstructorArgs([['alias' => 'First']])
+            ->setMethods(['getAlias'])
+            ->getMock();
+        $first->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('First');
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Muffin\Webservice\Model\Endpoint $first */
+        $second = $this->getMockBuilder(Endpoint::class)
+            ->setConstructorArgs([['alias' => 'Second']])
+            ->setMethods(['getAlias'])
+            ->getMock();
+        $second->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('Second');
+
+        $this->Locator->set($first->getAlias(), $first);
+        $this->Locator->set($second->getAlias(), $second);
+
+        $this->assertTrue($this->Locator->exists($first->getAlias()));
+        $this->assertTrue($this->Locator->exists($second->getAlias()));
+
+        $this->Locator->remove($second->getAlias());
+
+        $this->assertTrue($this->Locator->exists($first->getAlias()));
+        $this->assertFalse($this->Locator->exists($second->getAlias()));
+    }
+
+    public function testGet()
+    {
+        /** @var \Muffin\Webservice\Model\Endpoint $first */
+        $first = $this->getMockBuilder(Endpoint::class)
+            ->setConstructorArgs([['alias' => 'First']])
+            ->setMethods(['getAlias'])
+            ->getMock();
+        $first->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('First');
+
+        $this->Locator->set($first->getAlias(), $first);
+
+        $result = $this->Locator->get($first->getAlias());
+        $this->assertSame($first, $result);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage You cannot configure "First", it already exists in the registry.
+     */
+    public function testGetWithExistingObject()
+    {
+        $result = $this->Locator->get('First', [
+            'className' => Endpoint::class,
+            'registryAlias' => 'First',
+            'connection' => 'test'
+        ]);
+        $this->assertInstanceOf(Endpoint::class, $result);
+
+        $this->Locator->get('First', ['registryAlias' => 'NotFirst']);
+    }
+
+    public function testGetCreateInstance()
+    {
+        $result = $this->Locator->get('Test', [
+            'registryAlias' => 'Test',
+            'connection' => 'test'
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+    }
+
+    public function testGetInstanceWithNonExistentClass()
+    {
+        $result = $this->Locator->get('Test', [
+            'connection' => 'test',
+            'className' => 'UnfindableClass'
+        ]);
+
+        $this->assertInstanceOf(Endpoint::class, $result);
+        $this->assertEquals('unfindable_class', $result->getName());
+    }
+
+    public function testClear()
+    {
+        /** @var \Muffin\Webservice\Model\Endpoint $first */
+        $first = $this->getMockBuilder(Endpoint::class)
+            ->setConstructorArgs([['alias' => 'First']])
+            ->setMethods(['getAlias'])
+            ->getMock();
+        $first->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('First');
+
+        $this->Locator->set($first->getAlias(), $first);
+        $this->assertSame($first, $this->Locator->get($first->getAlias()));
+
+        $this->Locator->clear();
+
+        $this->assertFalse($this->Locator->exists($first->getAlias()));
+    }
+}


### PR DESCRIPTION
References #51 and https://github.com/cakephp/cakephp/issues/12014

The aim of this pull request is to deprecate the `EndpointRegistry` class and introduce a new `EndpointLocator` class which performs similar functionality. I have added deprecated a notice, written a new class using the old class as a base, and the CakePHP core `TableLocator` as a reference.

I have not updated the plugin boostraps use of `\Cake\Datasource\FactoryLocator::add()` as it seems this wants the callable to be static, which the LocatorInterface does not allow. My assumption is that it could be removed, as userland code will instantiate a new locator class instance to find endpoints?

