### PR TITLE
Reflect the changes to the Cake PHP 3.6 api in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ class Articles extends AbstractDriver
 {
 
     /**
-     * {@inheritDoc}
+     * Initialize is used to easily extend the constructor.
      */
     public function initialize()
     {
-        $this->client(new Client([
+        $this->setClient(new Client([
             'host' => 'example.com'
         ]));
     }
@@ -63,7 +63,6 @@ class Articles extends AbstractDriver
 
 namespace App\Webservice;
 
-use Cake\Network\Http\Client;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\ResultSet;
 use Muffin\Webservice\Webservice\Webservice;
@@ -72,11 +71,11 @@ class ArticlesWebservice extends Webservice
 {
 
     /**
-     * {@inheritDoc}
+     * Executes a query with the read action using the Cake HTTP Client
      */
     protected function _executeReadQuery(Query $query, array $options = [])
     {
-        $response = $this->driver()->client()->get('/articles.json');
+        $response = $this->getDriver()->getClient()->get('/articles.json');
 
         if (!$response->isOk()) {
             return false;
@@ -127,18 +126,19 @@ class Article extends Resource
 namespace App\Controller;
 
 use Cake\Event\Event;
+use Muffin\Webservice\Model\EndpointLocator;
 
 class ArticlesController extends AppController
 {
     public function initialize()
     {
         // You can also put this in AppController::initialize() itself
-        $this->modelFactory('Endpoint', ['Muffin\Webservice\Model\EndpointRegistry', 'get']);
+        $this->EndpointLocator = new EndpointLocator();
     }
 
     public function beforeFilter(Event $event)
     {
-        $this->loadModel('Articles', 'Endpoint');
+        $this->EndpointLocator->get('Articles');
     }
 
     public function index()


### PR DESCRIPTION
References #51 

The aim of this pull request is to update the README so that it accurately reflects the newer Cake 3.6 compatible api.

I am unsure if the controller implementation that I have documented is a the best approach. The Locator classes are still new to me, so I'm happy to get some help with this aspect of the proposed changes.