### PR TITLE
getResourceClass() should return $name if such class exists

### DIFF
--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -636,6 +636,8 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
             $name = implode('\\', array_slice($parts, 0, -1)) . '\Resource\\' . $alias;
             if (!class_exists($name)) {
                 return $this->_resourceClass = $default;
+            } else {
+                return $this->_resourceClass = $name;
             }
         }
 


### PR DESCRIPTION
Fixes #75