### PR TITLE
Added test case for #75

### DIFF
--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -636,6 +636,8 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
             $name = implode('\\', array_slice($parts, 0, -1)) . '\Resource\\' . $alias;
             if (!class_exists($name)) {
                 return $this->_resourceClass = $default;
+            } else {
+                return $this->_resourceClass = $name;
             }
         }
 

--- a/tests/TestCase/Model/EndpointTest.php
+++ b/tests/TestCase/Model/EndpointTest.php
@@ -9,6 +9,7 @@ use Muffin\Webservice\Model\Endpoint;
 use Muffin\Webservice\Model\Resource;
 use Muffin\Webservice\Query;
 use Muffin\Webservice\Test\test_app\Model\Endpoint\AppEndpoint;
+use Muffin\Webservice\Test\test_app\Model\Endpoint\ExampleEndpoint;
 use Muffin\Webservice\Test\test_app\Model\Endpoint\TestEndpoint;
 use Muffin\Webservice\Test\test_app\Webservice\TestWebservice;
 use Muffin\Webservice\Webservice\WebserviceInterface;
@@ -508,5 +509,12 @@ class EndpointTest extends TestCase
         $result = $this->endpoint->__debugInfo();
 
         $this->assertEquals($expected, $result);
+    }
+
+    public function testGetResourceWithCustomResource()
+    {
+        $endpoint = new ExampleEndpoint();
+
+        $this->assertEquals('Muffin\Webservice\Test\test_app\Model\Resource\Example', $endpoint->getResourceClass());
     }
 }

--- a/tests/test_app/Model/Endpoint/ExampleEndpoint.php
+++ b/tests/test_app/Model/Endpoint/ExampleEndpoint.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Muffin\Webservice\Test\test_app\Model\Endpoint;
+
+use Muffin\Webservice\Model\Endpoint;
+
+class ExampleEndpoint extends Endpoint
+{
+}


### PR DESCRIPTION
Added a new test case to ensure that when an endpoint is created with a custom resource class, that the class name is returned instead of the default or null.