### PR TITLE
Add after save callback

### DIFF
--- a/src/Model/Endpoint.php
+++ b/src/Model/Endpoint.php
@@ -1106,6 +1106,12 @@ class Endpoint implements RepositoryInterface, EventListenerInterface, EventDisp
             return false;
         }
 
+        $event = $this->dispatchEvent('Model.afterSave', compact('resource', 'options'));
+
+        if ($event->isStopped()) {
+            return $event->result;
+        }
+
         if (($resource->isNew()) && ($result instanceof EntityInterface)) {
             return $result;
         }


### PR DESCRIPTION
When an API returns a different result than the submitted data, we use "AfterSave" callback to catch this result