### PR TITLE
Supress jsonSerialize Return Notice

### DIFF
--- a/src/Datasource/Query.php
+++ b/src/Datasource/Query.php
@@ -592,6 +592,7 @@ class Query implements IteratorAggregate, JsonSerializable, QueryInterface
      *
      * @return \Cake\Datasource\ResultSetInterface The data to convert to JSON.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->all();


### PR DESCRIPTION
Return type of `Muffin\Webservice\Datasource\Query::jsonSerialize()` should either be compatible with `JsonSerializable::jsonSerialize(): mixed`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice.