### PR TITLE
Resource fields mapped to types

### DIFF
--- a/src/Webservice/Webservice.php
+++ b/src/Webservice/Webservice.php
@@ -356,13 +356,11 @@ abstract class Webservice implements WebserviceInterface
      */
     protected function _transformResource(Endpoint $endpoint, array $result): Resource
     {
-        $properties = [];
+        $entity = $endpoint->newEntity($result);
+        $entity->setNew(false);
+        $entity->clean();
 
-        foreach ($result as $property => $value) {
-            $properties[$property] = $value;
-        }
-
-        return $this->_createResource($endpoint->getResourceClass(), $properties);
+        return $entity;
     }
 
     /**


### PR DESCRIPTION
Fixes #108

`\Muffin\Webservice\Datasource\Marshaller` now correctly calls `TypeInterface::marshal()` on every mapped type.
(code is mostly copied from original CakePHP marshaller)

`\Muffin\Webservice\Webservice::_transformResource()` now calls `$endpoint->newEntity($result);` to trigger field mapping logic

`Model.afterMarshal` event is now correctly called after mapping